### PR TITLE
Fix Makefile recipes and validate dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,34 +3,34 @@ UV ?= uv
 .PHONY: help setup format lint typecheck test ci clean
 
 help:
-@echo "Common development commands:"
-@echo "  make setup     # install the package with development dependencies"
-@echo "  make format    # format code with ruff"
-@echo "  make lint      # lint code with ruff"
-@echo "  make typecheck # run pyright static analysis"
-@echo "  make test      # run pytest test suite"
-@echo "  make ci        # run the CI command set"
+	@echo "Common development commands:"
+	@echo "  make setup     # install the package with development dependencies"
+	@echo "  make format    # format code with ruff"
+	@echo "  make lint      # lint code with ruff"
+	@echo "  make typecheck # run pyright static analysis"
+	@echo "  make test      # run pytest test suite"
+	@echo "  make ci        # run the CI command set"
 
 setup:
-$(UV) pip install --system -e .[dev]
+	$(UV) pip install --system -e .[dev]
 
 format:
-ruff format .
+	ruff format .
 
 lint:
-ruff check .
+	ruff check .
 
 typecheck:
-pyright
+	pyright
 
 test:
-pytest
+	pytest
 
 ci:
-ruff format --check .
-ruff check .
-pyright
-pytest
+	ruff format --check .
+	ruff check .
+	pyright
+	pytest
 
 clean:
-rm -rf .pytest_cache .ruff_cache .pyright .pyright_cache build dist *.egg-info
+	rm -rf .pytest_cache .ruff_cache .pyright .pyright_cache build dist *.egg-info


### PR DESCRIPTION
## Summary
- replace space-indented Makefile recipes with proper tabs so `make` targets run
- execute the documented development workflow commands to verify they succeed in this environment

## Testing
- make setup
- make format
- make lint
- make typecheck
- make test
- make ci

------
https://chatgpt.com/codex/tasks/task_e_68dda9ca6b30832b83a384c04828508e