### PR TITLE
Remove unused pip cache from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3


### PR DESCRIPTION
## Summary
- remove the unused pip cache configuration from the setup-python step so the workflow no longer warns during cleanup

## Testing
- no tests needed; workflow-only change

------
https://chatgpt.com/codex/tasks/task_e_68ddabd472ec832b974dddfcde477c8b