### PR TITLE
Add dynamic-programming EHZ capacity solver and profiling harness

### DIFF
--- a/scripts/profile_ehz.py
+++ b/scripts/profile_ehz.py
@@ -1,0 +1,105 @@
+"""Profiling helpers for the polytope EHZ capacity implementations."""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+import numpy as np
+
+from viterbo import compute_ehz_capacity
+from viterbo.ehz_fast import compute_ehz_capacity_fast
+
+
+@dataclass
+class ProfileConfig:
+    """Configuration bundle describing a profiling experiment."""
+
+    label: str
+    function: Callable[[np.ndarray, np.ndarray], float]
+    repeats: int
+
+
+def _simplex_like_polytope_data(dimension: int = 4) -> tuple[np.ndarray, np.ndarray]:
+    B = np.eye(dimension)
+    extra = -np.ones((1, dimension))
+    B = np.vstack((B, extra))
+    c = np.ones(dimension + 1)
+    c[-1] = dimension / 2
+    return B, c
+
+
+def _simplex_with_extra_facet_data() -> tuple[np.ndarray, np.ndarray]:
+    B = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [-1.0, -1.0, -1.0, -1.0],
+            [0.0, 1.0, 0.0, 1.0],
+        ]
+    )
+    c = np.array([1.0, 1.0, 1.0, 1.0, 2.0, 1.2])
+    return B, c
+
+
+def _random_transformations(
+    B: np.ndarray,
+    c: np.ndarray,
+    *,
+    rng: np.random.Generator,
+    count: int,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Generate random linear transforms and translations of ``(B, c)``."""
+    dimension = B.shape[1]
+    results: list[tuple[np.ndarray, np.ndarray]] = []
+    for _ in range(count):
+        random_matrix = rng.normal(size=(dimension, dimension))
+        q, _ = np.linalg.qr(random_matrix)
+        scales = rng.uniform(0.7, 1.3, size=dimension)
+        transform = q @ np.diag(scales)
+        translated_B = B @ transform
+        translation = rng.normal(scale=0.2, size=dimension)
+        translated_c = c + translated_B @ translation
+        results.append((translated_B, translated_c))
+    return results
+
+
+def _profile(config: ProfileConfig, dataset: Sequence[tuple[np.ndarray, np.ndarray]]) -> None:
+    profiler = cProfile.Profile()
+    profiler.enable()
+    for _ in range(config.repeats):
+        for B, c in dataset:
+            config.function(B, c)
+    profiler.disable()
+    stats = pstats.Stats(profiler).sort_stats("cumtime")
+    print(f"\n=== Profile: {config.label} ===")
+    stats.print_stats(15)
+
+
+def main() -> None:
+    """Profile the reference and optimized capacity implementations."""
+    rng = np.random.default_rng(2024)
+    base_pairs = (
+        _simplex_like_polytope_data(),
+        _simplex_with_extra_facet_data(),
+    )
+    dataset: list[tuple[np.ndarray, np.ndarray]] = []
+    for B, c in base_pairs:
+        dataset.append((B, c))
+        dataset.extend(_random_transformations(B, c, rng=rng, count=15))
+
+    configs = (
+        ProfileConfig(label="reference", function=compute_ehz_capacity, repeats=5),
+        ProfileConfig(label="fast", function=compute_ehz_capacity_fast, repeats=5),
+    )
+
+    for config in configs:
+        _profile(config, dataset)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/viterbo/__init__.py
+++ b/src/viterbo/__init__.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from .core import normalize_vector
 from .ehz import compute_ehz_capacity, standard_symplectic_matrix
+from .ehz_fast import compute_ehz_capacity_fast
 from .hello import hello_numpy
 
 __all__ = [
     "compute_ehz_capacity",
+    "compute_ehz_capacity_fast",
     "hello_numpy",
     "normalize_vector",
     "standard_symplectic_matrix",

--- a/src/viterbo/ehz_fast.py
+++ b/src/viterbo/ehz_fast.py
@@ -1,0 +1,155 @@
+"""Optimized evaluation routines for the polytope EHZ capacity."""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+import numpy as np
+from jaxtyping import Float
+
+from .ehz import FacetSubset, _prepare_subset, standard_symplectic_matrix
+
+
+def compute_ehz_capacity_fast(
+    B: Float[np.ndarray, "num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
+    *,
+    tol: float = 1e-10,
+) -> float:
+    """
+    Compute the Ekeland–Hofer–Zehnder capacity using a dynamic program.
+
+    The outer structure of the algorithm mirrors :func:`viterbo.compute_ehz_capacity`
+    but replaces the exhaustive permutation search within each facet subset by a
+    dynamic programming routine. The DP exploits the antisymmetry of the Haim–Kislev
+    bilinear form to reduce the ``m!`` search over orders of ``m = 2n + 1`` facets
+    to ``O(m^2 2^m)`` states. For the small values of ``m`` relevant to symplectic
+    polytopes (``m <= 9`` in our experiments) this yields a pronounced speed-up
+    while staying in pure NumPy.
+
+    Parameters
+    ----------
+    B:
+        Outward pointing facet normals describing the polytope ``P = {x : Bx <= c}``.
+        The dimension of the ambient space equals ``2n`` with ``n >= 2``.
+    c:
+        Facet offsets for the inequality representation.
+    tol:
+        Numerical tolerance for feasibility checks and zero weights.
+
+    Returns
+    -------
+    float
+        The EHZ capacity of the polytope under the standard symplectic form.
+
+    Raises
+    ------
+    ValueError
+        If no admissible facet subset satisfies the non-negativity constraints in
+        the Reeb measure relations.
+
+    """
+    B = np.asarray(B, dtype=float)
+    c = np.asarray(c, dtype=float)
+
+    if B.ndim != 2:
+        raise ValueError("Facet matrix B must be two-dimensional.")
+
+    if c.ndim != 1 or c.shape[0] != B.shape[0]:
+        raise ValueError("Vector c must have length equal to the number of facets.")
+
+    num_facets, dimension = B.shape
+    if dimension % 2 != 0 or dimension < 4:
+        raise ValueError("The ambient dimension must satisfy 2n with n >= 2.")
+
+    J = standard_symplectic_matrix(dimension)
+    subset_size = dimension + 1
+    best_capacity = np.inf
+
+    for indices in combinations(range(num_facets), subset_size):
+        subset = _prepare_subset(B=B, c=c, indices=indices, J=J, tol=tol)
+        if subset is None:
+            continue
+
+        candidate_value = _subset_capacity_candidate_fast(subset, tol=tol)
+        if candidate_value is None:
+            continue
+
+        if candidate_value < best_capacity:
+            best_capacity = candidate_value
+
+    if not np.isfinite(best_capacity):
+        raise ValueError("No admissible facet subset satisfied the non-negativity constraints.")
+
+    return best_capacity
+
+
+def _subset_capacity_candidate_fast(subset: FacetSubset, *, tol: float) -> float | None:
+    beta = subset.beta
+    symplectic_products = subset.symplectic_products
+
+    positive = np.where(beta > tol)[0]
+    if positive.size < 2:
+        return None
+
+    beta_active = beta[positive]
+    W_active = symplectic_products[np.ix_(positive, positive)]
+    weights = np.multiply.outer(beta_active, beta_active) * W_active
+
+    # The skew-symmetry of ``W`` implies zero diagonal, but we zero it explicitly to
+    # guard against numerical noise.
+    np.fill_diagonal(weights, 0.0)
+
+    maximal_value = _maximum_antisymmetric_order_value(weights)
+    if maximal_value <= tol:
+        return None
+
+    return 0.5 / maximal_value
+
+
+def _maximum_antisymmetric_order_value(weights: np.ndarray) -> float:
+    """
+    Return the maximum order value for the antisymmetric weight matrix.
+
+    Parameters
+    ----------
+    weights:
+        Square matrix ``W`` with ``W[i, j] = -W[j, i]`` encoding the bilinear form
+        contributions between active facets after weighting by the Reeb measure.
+
+    """
+    m = weights.shape[0]
+    if m == 0:
+        return 0.0
+
+    size = 1 << m
+    dp = np.full(size, -np.inf)
+    dp[0] = 0.0
+
+    prefix_sums = np.zeros((m, size))
+    for idx in range(m):
+        for mask in range(1, size):
+            lsb = mask & -mask
+            bit_index = lsb.bit_length() - 1
+            prev_mask = mask ^ lsb
+            prefix_sums[idx, mask] = prefix_sums[idx, prev_mask] + weights[idx, bit_index]
+
+    for mask in range(size):
+        current = dp[mask]
+        if not np.isfinite(current):
+            continue
+
+        remaining = (~mask) & (size - 1)
+        while remaining:
+            lsb = remaining & -remaining
+            next_index = lsb.bit_length() - 1
+            new_mask = mask | lsb
+            candidate = current + prefix_sums[next_index, mask]
+            if candidate > dp[new_mask]:
+                dp[new_mask] = candidate
+            remaining ^= lsb
+
+    return dp[-1]
+
+
+__all__ = ["compute_ehz_capacity_fast"]

--- a/tests/test_ehz_capacity_fast.py
+++ b/tests/test_ehz_capacity_fast.py
@@ -1,0 +1,96 @@
+"""Tests ensuring the optimized EHZ capacity implementation matches the reference."""
+
+from __future__ import annotations
+
+from itertools import permutations
+
+import numpy as np
+
+from viterbo import compute_ehz_capacity
+from viterbo.ehz_fast import (
+    _maximum_antisymmetric_order_value,
+    compute_ehz_capacity_fast,
+)
+
+
+def _simplex_like_polytope_data(dimension: int = 4) -> tuple[np.ndarray, np.ndarray]:
+    B = np.eye(dimension)
+    extra = -np.ones((1, dimension))
+    B = np.vstack((B, extra))
+    c = np.ones(dimension + 1)
+    c[-1] = dimension / 2
+    return B, c
+
+
+def _simplex_with_extra_facet_data() -> tuple[np.ndarray, np.ndarray]:
+    B = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [-1.0, -1.0, -1.0, -1.0],
+            [0.0, 1.0, 0.0, 1.0],
+        ]
+    )
+    c = np.array([1.0, 1.0, 1.0, 1.0, 2.0, 1.2])
+    return B, c
+
+
+def _generate_variants(
+    B: np.ndarray,
+    c: np.ndarray,
+    *,
+    rng: np.random.Generator,
+    count: int,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    dimension = B.shape[1]
+    results: list[tuple[np.ndarray, np.ndarray]] = []
+    for _ in range(count):
+        random_matrix = rng.normal(size=(dimension, dimension))
+        q, _ = np.linalg.qr(random_matrix)
+        scales = rng.uniform(0.6, 1.4, size=dimension)
+        transform = q @ np.diag(scales)
+        transformed_B = B @ transform
+        translation = rng.normal(scale=0.3, size=dimension)
+        transformed_c = c + transformed_B @ translation
+        results.append((transformed_B, transformed_c))
+    return results
+
+
+def test_dynamic_program_matches_bruteforce() -> None:
+    rng = np.random.default_rng(0)
+    weights = rng.normal(size=(5, 5))
+    weights = weights - weights.T
+
+    brute = -np.inf
+    for order in permutations(range(5)):
+        total = 0.0
+        for i in range(1, 5):
+            idx_i = order[i]
+            for j in range(i):
+                idx_j = order[j]
+                total += weights[idx_i, idx_j]
+        brute = max(brute, total)
+
+    dp_value = _maximum_antisymmetric_order_value(weights)
+    assert np.isclose(dp_value, brute)
+
+
+def test_fast_implementation_matches_reference() -> None:
+    rng = np.random.default_rng(2023)
+    base_polytopes = [
+        _simplex_like_polytope_data(),
+        _simplex_with_extra_facet_data(),
+        _simplex_like_polytope_data(6),
+    ]
+
+    instances: list[tuple[np.ndarray, np.ndarray]] = []
+    for B, c in base_polytopes:
+        instances.append((B, c))
+        instances.extend(_generate_variants(B, c, rng=rng, count=3))
+
+    for B, c in instances:
+        reference = compute_ehz_capacity(B, c)
+        optimized = compute_ehz_capacity_fast(B, c)
+        assert np.isclose(reference, optimized, atol=1e-8)


### PR DESCRIPTION
## Summary
- add a dynamic-programming based `compute_ehz_capacity_fast` that reuses the existing facet enumeration but avoids factorial facet order search
- add targeted tests that compare the DP helper against brute-force evaluation and validate the fast solver against the trusted reference implementation across transformed polytopes
- provide a profiling script to measure the reference and optimized solvers on randomized datasets

## Testing
- make lint
- make test
- python scripts/profile_ehz.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbf554cd0832bb90bd9c90f4507a4