### PR TITLE
Introduce pytest-based performance workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,14 @@ dist/
 .venv/
 .uv/
 .pytest_cache/
+.benchmarks/
 .mypy_cache/
 ruff_cache/
 .pyright/
+
+# Profiling artefacts
+profile.svg
+*.prof
 
 # Coverage reports
 htmlcov/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ update those docs to match this.
   - Provide docstrings for public APIs, include shape information inline where helpful.
   - Annotate NumPy arrays with jaxtyping types and inline shape comments (`# shape: (n,)`).
   - Run `make format`, `make lint`, and `make test` locally before committing.
+  - Use the performance workflows below whenever you touch optimized kernels.
 - Local CI Check
   - Run `make ci` to mirror the GitHub Actions workflow (ruff check/format, pyright, pytest).
   - Resolve all lint and typecheck warnings; treat warnings as errors.
@@ -49,6 +50,7 @@ update those docs to match this.
 - Project Layout
   - `src/viterbo/` — Python package with functional core helpers.
   - `tests/` — pytest test suite.
+    - `tests/performance/` centralizes benchmarks that reuse the same fixtures as regression tests.
   - `docs/` — overview + numbered references (project, math, tooling). Onboarding lives in this file.
   - `tmp/` — ignored scratch area for copied papers/notes you intend to incorporate later; do not commit raw notes.
   - `.devcontainer/` — container config and lifecycle scripts.
@@ -57,6 +59,18 @@ update those docs to match this.
   - GitHub Actions on push/PR (Linux only): checkout, setup Python 3.12, cache pip, install deps, run Ruff format check, Ruff lint, Pyright, pytest.
   - Concurrency cancels in-progress runs per ref.
   - Coverage policy: upload-only TBD; currently no coverage upload or threshold.
+
+**Performance Workflows**
+- Install tooling via `make setup` (includes pytest-benchmark, pytest-profiling, pytest-line-profiler, scalene, and py-spy).
+- Benchmarks live in `tests/performance/` and double as correctness checks.
+  - `make bench` → run only benchmarked tests with autosaved stats under `.benchmarks/`.
+  - `make profile` → wrap the same suite in `cProfile` for call graph exploration (`pytest --profile`).
+  - `make profile-line` → activate `line_profiler` for the fast kernel (`pytest --line-profile viterbo.ehz_fast.compute_ehz_capacity_fast`).
+- Mark new optimized workloads with `@pytest.mark.benchmark` and (optionally) `@pytest.mark.line_profile("path.to.function")`.
+- Prefer extending `tests/_polytope_samples.py` when adding datasets so benchmarks and regression tests stay aligned.
+- For deep dives outside pytest, use the installed standalone tools:
+  - `scalene path/to/script.py` for CPU/GPU/memory sampling.
+  - `py-spy top --pid <pid>` or `py-spy record -o profile.svg -- python script.py` for low-overhead profiling.
 - Security
   - Never log secrets; environment variables only; avoid `set -x` and echoing env.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UV ?= uv
 
-.PHONY: help setup format lint typecheck test ci clean
+.PHONY: help setup format lint typecheck test bench profile profile-line ci clean
 
 help:
 	@echo "Common development commands:"
@@ -9,6 +9,9 @@ help:
 	@echo "  make lint      # lint code with ruff"
 	@echo "  make typecheck # run pyright static analysis"
 	@echo "  make test      # run pytest test suite"
+	@echo "  make bench     # run pytest benchmarks in tests/performance"
+	@echo "  make profile   # run pytest with cProfile on performance suite"
+	@echo "  make profile-line # run pytest with line_profiler on the fast kernel"
 	@echo "  make ci        # run the CI command set"
 
 setup:
@@ -25,6 +28,15 @@ typecheck:
 
 test:
 	pytest
+
+bench:
+	pytest tests/performance --benchmark-only --benchmark-autosave --benchmark-storage=.benchmarks
+
+profile:
+	pytest tests/performance --profile
+
+profile-line:
+	pytest tests/performance --line-profile viterbo.ehz_fast.compute_ehz_capacity_fast
 
 ci:
 	ruff format --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,13 @@ dev = [
     "pyright>=1.1.375",
     "pytest>=8.1",
     "pytest-xdist>=3.6",
+    "pytest-benchmark>=4.0",
+    "pytest-codspeed>=2.2",
+    "pytest-profiling>=1.7",
+    "pytest-line-profiler>=0.2",
+    "line-profiler>=5.0",
+    "scalene>=1.5",
+    "py-spy>=0.3",
     "ruff>=0.4.8",
 ]
 
@@ -29,6 +36,10 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+markers = [
+    "benchmark: marks tests that exercise pytest-benchmark fixtures.",
+    "line_profile: profile annotated tests with line_profiler.",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite package to enable relative imports for shared fixtures."""

--- a/tests/_polytope_samples.py
+++ b/tests/_polytope_samples.py
@@ -1,0 +1,48 @@
+"""Shared fixtures for generating representative polytope instances for tests.
+
+We centralize the catalog sampling logic so both correctness and performance
+suites iterate over the exact same data. This avoids accidental drift between
+benchmark inputs and the regression tests that guard correctness.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Final
+
+import numpy as np
+
+from viterbo.polytopes import catalog, random_transformations
+
+
+def load_polytope_instances(
+    *,
+    rng_seed: int = 2023,
+    variant_count: int = 3,
+) -> tuple[Sequence[tuple[np.ndarray, np.ndarray]], Sequence[str]]:
+    """Return a deterministic list of polytopes plus readable identifiers.
+
+    The optimized and reference implementations are sensitive to both the
+    polytope geometry and the affine transformations we apply. Supplying a
+    fixed RNG seed keeps tests reproducible while allowing us to reuse the
+    sample set across correctness, benchmarking, and profiling runs.
+    """
+
+    rng = np.random.default_rng(rng_seed)
+    instances: list[tuple[np.ndarray, np.ndarray]] = []
+    identifiers: list[str] = []
+
+    for polytope in catalog():
+        B, c = polytope.halfspace_data()
+        instances.append((B, c))
+        identifiers.append(polytope.name)
+
+        variants = random_transformations(polytope, rng=rng, count=variant_count)
+        for index, (variant_B, variant_c) in enumerate(variants):
+            instances.append((variant_B, variant_c))
+            identifiers.append(f"{polytope.name}-variant-{index}")
+
+    return instances, identifiers
+
+
+__all__: Final = ["load_polytope_instances"]

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -1,0 +1,1 @@
+"""Performance-focused tests share fixtures via the parent ``tests`` package."""

--- a/tests/performance/test_ehz_capacity_benchmarks.py
+++ b/tests/performance/test_ehz_capacity_benchmarks.py
@@ -1,0 +1,54 @@
+"""Performance-focused tests for the EHZ capacity implementations.
+
+These tests live alongside the correctness suite to keep benchmarking
+ergonomic for contributors. The additional comments explain how the pytest
+plugins compose so future maintainers can extend the pattern to other modules.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import pytest_benchmark.plugin
+
+from viterbo import compute_ehz_capacity
+from viterbo.ehz_fast import compute_ehz_capacity_fast
+
+from .._polytope_samples import load_polytope_instances
+
+# Reuse the exact same catalog of polytopes as the regression tests so that any
+# deviation caught here points to a performance-only issue rather than a change
+# in sampling. The helper also carries documentation about why the instances are
+# structured the way they are. We keep line-profiler opt-in via CLI (`make
+# profile-line`) to avoid noisy output during normal pytest runs.
+_POLYTOPE_INSTANCES, _POLYTOPE_IDS = load_polytope_instances()
+
+
+@pytest.mark.benchmark(group="ehz_capacity")
+@pytest.mark.parametrize(("B", "c"), _POLYTOPE_INSTANCES, ids=_POLYTOPE_IDS)
+def test_fast_ehz_capacity_matches_reference_and_tracks_speed(
+    benchmark: pytest_benchmark.plugin.BenchmarkFixture,
+    B: np.ndarray,
+    c: np.ndarray,
+) -> None:
+    """Benchmark the optimized kernel and assert it still agrees with reference.
+
+    The ``benchmark`` fixture repeatedly calls the optimized implementation and
+    returns the last result so we can validate correctness inline. Pytest's
+    normal assertion rewriting remains active, which keeps this single source
+    of truth for both performance and accuracy checks.
+    """
+
+    try:
+        reference = compute_ehz_capacity(B, c)
+    except ValueError as error:
+        # When the reference rejects an instance (e.g. infeasible constraints)
+        # we still run the optimized variant through the benchmark harness so
+        # the failure is visible in timing reports. Pytest-benchmark re-raises
+        # the underlying exception, letting us assert on parity of the message.
+        with pytest.raises(ValueError) as caught:
+            benchmark(lambda: compute_ehz_capacity_fast(B, c))
+        assert str(caught.value) == str(error)
+    else:
+        optimized = benchmark(lambda: compute_ehz_capacity_fast(B, c))
+        assert np.isclose(optimized, reference, atol=1e-8)

--- a/tests/test_ehz_capacity_fast.py
+++ b/tests/test_ehz_capacity_fast.py
@@ -12,7 +12,8 @@ from viterbo.ehz_fast import (
     _maximum_antisymmetric_order_value,
     compute_ehz_capacity_fast,
 )
-from viterbo.polytopes import catalog, random_transformations
+
+from ._polytope_samples import load_polytope_instances
 
 
 def test_dynamic_program_matches_bruteforce() -> None:
@@ -34,24 +35,7 @@ def test_dynamic_program_matches_bruteforce() -> None:
     assert np.isclose(dp_value, brute)
 
 
-def _instances() -> tuple[list[tuple[np.ndarray, np.ndarray]], list[str]]:
-    rng = np.random.default_rng(2023)
-    instances: list[tuple[np.ndarray, np.ndarray]] = []
-    ids: list[str] = []
-    for polytope in catalog():
-        B, c = polytope.halfspace_data()
-        instances.append((B, c))
-        ids.append(polytope.name)
-
-        variants = random_transformations(polytope, rng=rng, count=3)
-        for index, (variant_B, variant_c) in enumerate(variants):
-            instances.append((variant_B, variant_c))
-            ids.append(f"{polytope.name}-variant-{index}")
-
-    return instances, ids
-
-
-_POLYTOPE_INSTANCES, _POLYTOPE_IDS = _instances()
+_POLYTOPE_INSTANCES, _POLYTOPE_IDS = load_polytope_instances()
 
 
 @pytest.mark.parametrize(("B", "c"), _POLYTOPE_INSTANCES, ids=_POLYTOPE_IDS)


### PR DESCRIPTION
## Summary
- add popular pytest benchmarking and profiling plugins to the dev environment and surface new make targets for them
- share a deterministic polytope catalog between regression and performance suites and add a benchmark that asserts parity with the reference implementation
- document the performance workflow in AGENTS.md and ignore generated benchmark/profiling artefacts

## Testing
- pytest
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68de1eeaedac832b831d3a5539e4a548