### PR TITLE
Add py.typed marker and document typed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Preferred workflow (`make` targets, backed by `uv`):
 - Typecheck: `make typecheck`
 - Full CI mirror: `make ci`
 
+## Typing
+
+The published `viterbo` package ships a `py.typed` marker so type checkers consume the
+inline annotations. Please keep signatures and jaxtyping shapes accurate when touching
+the codebase.
+
 ## Repository Layout
 
 - `src/viterbo/`: Python package with numerical helpers and experiments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dev = [
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+"viterbo" = ["py.typed"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"


### PR DESCRIPTION
## Summary
- add a py.typed marker to expose inline type hints to downstream users
- configure setuptools to ship the marker in built distributions
- document the typed package status for contributors in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deb17159a4832b925a3b4d6fdfad50