### PR TITLE
Run pyright on tests and fix benchmark typing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ update those docs to match this.
 - Local CI Check
   - Run `make ci` to mirror the GitHub Actions workflow (ruff check/format, pyright, pytest).
   - Resolve all lint and typecheck warnings; treat warnings as errors.
+  - Pyright covers both `src/` and `tests/`; keep the full suite type-clean, including fixtures and benchmarks.
 - Devcontainer (Codex Cloud)
   - One-time: `bash .devcontainer/post-create.sh`
   - Every boot: `bash .devcontainer/post-start.sh`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,5 @@ ignore = [
 
 [tool.pyright]
 pythonVersion = "3.12"
-include = ["src"]
-ignore = ["tests"]
+include = ["src", "tests"]
 reportMissingImports = "warning"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/pyright/main/packages/pyright/schemas/pyrightconfig.schema.json",
-  "include": ["src"],
-  "exclude": ["tests"],
+  "include": ["src", "tests"],
   "pythonVersion": "3.12",
   "reportMissingImports": "warning"
 }

--- a/tests/performance/test_volume_benchmarks.py
+++ b/tests/performance/test_volume_benchmarks.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+import pytest_benchmark.plugin
 
 from viterbo import random_polytope
 from viterbo.volume import polytope_volume_fast, polytope_volume_reference
 
 
 @pytest.mark.benchmark
-def test_volume_fast_matches_reference(benchmark: pytest.BenchmarkFixture) -> None:
+def test_volume_fast_matches_reference(
+    benchmark: pytest_benchmark.plugin.BenchmarkFixture,
+) -> None:
     rng = np.random.default_rng(314)
     polytope = random_polytope(4, rng=rng, name="volume-bench")
     B, c = polytope.halfspace_data()


### PR DESCRIPTION
## Summary
- configure Pyright to analyze both the library code and the test suite
- document that contributors must keep tests type-clean now that Pyright runs on them
- update benchmark tests to use the concrete pytest-benchmark fixture typing

## Testing
- make typecheck

------
https://chatgpt.com/codex/tasks/task_e_68deb1380078832baf6c99754a83e2bb