### PR TITLE
Add scheduled performance benchmark workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 1"
 
 jobs:
   build:
@@ -35,3 +38,38 @@ jobs:
 
       - name: Pytest
         run: pytest
+
+  performance-benchmarks:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv pip install --system -e .[dev]
+
+      - name: Run performance benchmarks
+        run: >-
+          pytest tests/performance
+          --benchmark-only
+          --benchmark-autosave
+          --benchmark-storage=.benchmarks
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-history
+          path: .benchmarks
+          if-no-files-found: error
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Preferred workflow (`make` targets, backed by `uv`):
 GitHub Actions runs Ruff format checks, Ruff lint, Pyright, and pytest on pushes and pull requests
 (see `.github/workflows/ci.yml`).
 
+### Performance benchmarks
+
+- A dedicated `performance-benchmarks` job runs weekly (Mondays at 05:00 UTC) or on-demand via
+  the **Run workflow** button. It installs the dev dependencies and executes
+  `pytest tests/performance --benchmark-only --benchmark-autosave --benchmark-storage=.benchmarks`.
+- Benchmark outputs are uploaded as a `benchmark-history` workflow artifact so regressions can be
+  tracked locally. Download the latest artifact and unpack `.benchmarks/` to compare against your
+  branch, or regenerate locally with `make bench` for a quick spot check.
+
 ## License
 
 MIT License — see `LICENSE`.


### PR DESCRIPTION
## Summary
- add a scheduled/manual performance benchmark job to the CI workflow that runs the pytest benchmark suite and uploads autosaved results
- publish the `.benchmarks` directory as a reusable workflow artifact for historical comparison
- document how contributors can trigger the benchmark workflow and consume its artifacts in the README

## Testing
- not run (workflow/docs only)


------
https://chatgpt.com/codex/tasks/task_e_68deab4bd5c0832bbf3f4c5a7b56d99f