### PR TITLE
Validate Haim–Kislev action order input

### DIFF
--- a/src/viterbo/polytopes.py
+++ b/src/viterbo/polytopes.py
@@ -376,6 +376,19 @@ def haim_kislev_action(
     c_subset = offsets[rows]
     m = len(rows)
 
+    order_tuple = tuple(order)
+    if len(order_tuple) != m:
+        msg = "Facet order must include each subset index exactly once."
+        raise ValueError(msg)
+    if not all(isinstance(idx, (int, np.integer)) for idx in order_tuple):
+        msg = "Facet order must contain integer indices."
+        raise ValueError(msg)
+
+    order_indices = np.asarray(order_tuple, dtype=int)
+    if not np.array_equal(np.sort(order_indices), np.arange(m)):
+        msg = "Facet order must be a permutation of range(m)."
+        raise ValueError(msg)
+
     system = np.zeros((m, m))
     system[0, :] = c_subset
     system[1:, :] = B_subset.T

--- a/tests/test_haim_kislev_action.py
+++ b/tests/test_haim_kislev_action.py
@@ -1,0 +1,25 @@
+"""Unit tests for the Haim–Kislev action helper."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from viterbo.polytopes import haim_kislev_action, truncated_simplex_four_dim
+
+
+def test_haim_kislev_action_valid_order_matches_reference_capacity() -> None:
+    polytope = truncated_simplex_four_dim()
+    subset = (0, 1, 2, 3, 4)
+    order = (2, 0, 4, 3, 1)
+    action = haim_kislev_action(polytope.B, polytope.c, subset=subset, order=order)
+    assert math.isclose(action, polytope.reference_capacity)
+
+
+def test_haim_kislev_action_invalid_order_raises_value_error() -> None:
+    polytope = truncated_simplex_four_dim()
+    subset = (0, 1, 2, 3, 4)
+    invalid_order = (2, 0, 4, 4, 1)
+    with pytest.raises(ValueError):
+        haim_kislev_action(polytope.B, polytope.c, subset=subset, order=invalid_order)


### PR DESCRIPTION
## Summary
- validate the facet order before solving for the Haim–Kislev action
- cover valid and invalid facet order scenarios with targeted tests

## Testing
- pytest tests/test_haim_kislev_action.py

------
https://chatgpt.com/codex/tasks/task_e_68deab4773ac832ba78488192837ee9d