### PR TITLE
Allow EHZ capacity computation in 2D

### DIFF
--- a/src/viterbo/ehz.py
+++ b/src/viterbo/ehz.py
@@ -44,7 +44,7 @@ def standard_symplectic_matrix(dimension: int) -> np.ndarray:
     Parameters
     ----------
     dimension:
-        An even integer at least four. The resulting matrix encodes the
+        An even integer at least two. The resulting matrix encodes the
         bilinear form ``\omega(x, y) = x^{\mathsf{T}} J y`` with the block
         structure ``J = [[0, I_n], [-I_n, 0]]`` for ``n = d/2``.
 
@@ -56,11 +56,11 @@ def standard_symplectic_matrix(dimension: int) -> np.ndarray:
     Raises
     ------
     ValueError
-        If ``dimension`` is not an even integer greater or equal to four.
+        If ``dimension`` is not an even integer greater or equal to two.
 
     """
-    if dimension % 2 != 0 or dimension < 4:
-        msg = "The standard symplectic matrix is defined for even d >= 4."
+    if dimension % 2 != 0 or dimension < 2:
+        msg = "The standard symplectic matrix is defined for even d >= 2."
         raise ValueError(msg)
 
     half = dimension // 2
@@ -84,7 +84,7 @@ def compute_ehz_capacity(
     B:
         Matrix whose rows describe outward pointing facet normals of a convex
         polytope ``P`` via the inequality description ``P = \{x : B x \leq c\}``.
-        The ambient dimension equals ``d = 2n`` with ``n \geq 2``.
+        The ambient dimension equals ``d = 2n`` with ``n \geq 1``.
     c:
         Vector of offsets appearing in the facet inequalities. The i-th
         inequality is ``\langle b_i, x \rangle \leq c_i``.
@@ -117,7 +117,7 @@ def compute_ehz_capacity(
     Raises
     ------
     ValueError
-        If the dimension is not even and at least four or if no admissible
+        If the dimension is not even and at least two or if no admissible
         facet subset satisfies the non-negativity constraints implied by the
         Reeb measure relations.
 
@@ -132,8 +132,8 @@ def compute_ehz_capacity(
         raise ValueError("Vector c must have length equal to the number of facets.")
 
     num_facets, dimension = B.shape
-    if dimension % 2 != 0 or dimension < 4:
-        raise ValueError("The ambient dimension must satisfy 2n with n >= 2.")
+    if dimension % 2 != 0 or dimension < 2:
+        raise ValueError("The ambient dimension must satisfy 2n with n >= 1.")
 
     J = standard_symplectic_matrix(dimension)
     subset_size = dimension + 1

--- a/src/viterbo/ehz_fast.py
+++ b/src/viterbo/ehz_fast.py
@@ -31,7 +31,7 @@ def compute_ehz_capacity_fast(
     ----------
     B:
         Outward pointing facet normals describing the polytope ``P = {x : Bx <= c}``.
-        The dimension of the ambient space equals ``2n`` with ``n >= 2``.
+        The dimension of the ambient space equals ``2n`` with ``n >= 1``.
     c:
         Facet offsets for the inequality representation.
     tol:
@@ -59,8 +59,8 @@ def compute_ehz_capacity_fast(
         raise ValueError("Vector c must have length equal to the number of facets.")
 
     num_facets, dimension = B.shape
-    if dimension % 2 != 0 or dimension < 4:
-        raise ValueError("The ambient dimension must satisfy 2n with n >= 2.")
+    if dimension % 2 != 0 or dimension < 2:
+        raise ValueError("The ambient dimension must satisfy 2n with n >= 1.")
 
     J = standard_symplectic_matrix(dimension)
     subset_size = dimension + 1

--- a/tests/test_ehz_capacity.py
+++ b/tests/test_ehz_capacity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from viterbo import compute_ehz_capacity
+from viterbo import compute_ehz_capacity, compute_ehz_capacity_fast
 from viterbo.polytopes import (
     Polytope,
     catalog,
@@ -69,3 +69,17 @@ def test_truncated_simplex_matches_known_subset_action() -> None:
 
     assert polytope.reference_capacity is not None
     assert np.isclose(capacity, polytope.reference_capacity, atol=1e-9)
+
+
+def test_two_dimensional_simplex_matches_fast_capacity() -> None:
+    """The 2D simplex yields a finite, consistent capacity across implementations."""
+
+    polytope = simplex_with_uniform_weights(2, name="simplex-2d-test")
+    B, c = polytope.halfspace_data()
+
+    reference = compute_ehz_capacity(B, c)
+    optimized = compute_ehz_capacity_fast(B, c)
+
+    assert np.isfinite(reference)
+    assert np.isfinite(optimized)
+    assert np.isclose(reference, optimized, atol=1e-9)


### PR DESCRIPTION
## Summary
- relax the standard symplectic and EHZ capacity guards to accept any even dimension >= 2
- update the associated documentation strings
- add a regression test that exercises the 2D simplex with both EHZ implementations

## Testing
- pytest tests/test_ehz_capacity.py tests/test_ehz_capacity_fast.py

------
https://chatgpt.com/codex/tasks/task_e_68deab4110f4832b95968a00b6045568