### PR TITLE
docs: schedule symplectic invariants suite

### DIFF
--- a/docs/tasks/02-task-portfolio.md
+++ b/docs/tasks/02-task-portfolio.md
@@ -12,6 +12,7 @@ visible at a glance.
 | --- | --- | --- | --- | --- | --- | --- |
 | T1 | [Geometry quantity module restructure & JAX baselines](scheduled/2025-10-04-geometry-module-refactor.md) | Scheduled | **+3.15** | Medium / Low / Low | 0 | Root of SWE work; enables all downstream experiments. |
 | T2 | [Testing, benchmarking, and profiling harness](draft/2025-10-04-testing-benchmark-harness.md) | Draft | **+2.30** | Medium / Low / Low | 0.5 | Lands immediately after T1 to secure regression safety. |
+| T3 | [Symplectic invariants regression suite](scheduled/2025-10-05-symplectic-invariant-regression-suite.md) | Scheduled | **+2.50** | Medium / Low / Medium | 0.75 | Hardens invariants before dataset work. |
 | E1 | [Facet-normal validation & dataset build](draft/2025-10-04-facet-dataset.md) | Draft | **+2.70** | Medium / Low / Low | 1 | First numerical experiment; seeds data for the rest. |
 | E2 | [Reeb orbit cross-check](draft/2025-10-04-reeb-cross-check.md) | Draft | **+2.10** | Medium / Low / Low | 2 | Tests numerical agreement across methods. |
 | E3 | [MILP relaxation bounds](draft/2025-10-04-milp-relaxations.md) | Draft | **+1.40** | Medium / Medium / Medium | 3 | Evaluates feasibility of open-source MILP tooling. |
@@ -19,16 +20,17 @@ visible at a glance.
 | E5 | [Support-function relaxation stress test](draft/2025-10-04-support-function-stress.md) | Draft | **+0.90** | Medium / Medium / Low | 5 | Probes robustness of relaxation techniques. |
 
 Expected utilities remain the sum of probability-weighted utilities captured in
-the owning briefs. Priorities reflect the qualitative ordering: complete T1 and
-T2 before launching the dataset or analysis experiments.
+the owning briefs. Priorities reflect the qualitative ordering: complete T1–T3
+before launching the dataset or analysis experiments.
 
 ## 2. Dependency structure
 
 ```mermaid
 graph TD
   T1["T1\nGeometry module restructure"] --> T2["T2\nTesting & benchmarks"]
-  T1 --> E1["E1\nFacet dataset"]
-  T2 --> E1
+  T1 --> T3["T3\nInvariant regression suite"]
+  T2 --> T3
+  T3 --> E1["E1\nFacet dataset"]
   E1 --> E2["E2\nReeb cross-check"]
   E1 --> E3["E3\nMILP bounds"]
   E1 --> E4["E4\nCapacity-volume study"]
@@ -55,6 +57,13 @@ Update this graph whenever briefs change status or new items enter the queue.
   cadence.
 - **Next checkpoint**: validate smoke benchmark runtime (<5 minutes) before
   enabling in CI.
+
+### T3 — Symplectic invariants regression suite
+- **Brief**: [`docs/tasks/scheduled/2025-10-05-symplectic-invariant-regression-suite.md`](scheduled/2025-10-05-symplectic-invariant-regression-suite.md)
+- **Why it matters**: codifies core invariants across reference/optimised/JAX implementations so downstream experiments inherit
+  trusted guarantees and surface failures quickly.
+- **Next checkpoint**: confirm the invariant inventory with the maintainer and
+  stabilise smoke/deep marker runtimes.
 
 ### E1 — Facet-normal validation & dataset build
 - **Brief**: [`docs/tasks/draft/2025-10-04-facet-dataset.md`](draft/2025-10-04-facet-dataset.md)

--- a/docs/tasks/draft/2025-10-04-testing-benchmark-harness.md
+++ b/docs/tasks/draft/2025-10-04-testing-benchmark-harness.md
@@ -1,19 +1,19 @@
 # Task Brief — Testing, benchmarking, and profiling harness
 
 - **Status**: Draft
-- **Last updated**: 2025-10-04
+- **Last updated**: 2025-10-05
 - **Owner / DRI**: Unassigned
 - **Related docs**: `docs/tasks/01-task-evaluation-methodology.md`, `docs/tasks/02-task-portfolio.md`, `docs/algorithm-implementation-plan.md`
 
 ## 1. Context and intent
-After the geometry module restructure (Task 2025-10-04-geometry-module-refactor), we need automated verification to prevent regressions. This task establishes unit comparisons across implementation variants, codifies benchmark tiers (smoke, CI, deep, long-haul), and wires profiling entry points so agents can reason about performance before launching computational experiments.
+After the geometry module restructure (Task 2025-10-04-geometry-module-refactor), we need automated verification to prevent regressions. This task establishes unit comparisons across implementation variants, codifies benchmark tiers (smoke, CI, deep, long-haul), wires profiling entry points, and ensures these hooks integrate with the existing `Makefile` + `pytest.ini` tooling so agents can reason about performance before launching computational experiments.
 
 ## 2. Objectives and non-goals
 
 ### In scope
 - Build unit tests that compare reference, optimised, and JAX implementations on shared fixtures and transformation checks.
-- Create pytest benchmark collections tagged by tier (`smoke`, `ci`, `deep`, `longhaul`) so CI and local runs can select the right scope quickly.
-- Add profiling recipes (e.g., `python -m cProfile`, `pyinstrument`) for the most critical code paths with instructions stored under `docs/` or `tests/performance/`.
+- Create pytest benchmark collections tagged by tier (`smoke`, `ci`, `deep`, `longhaul`) so CI and local runs can select the right scope quickly, including `pytest.ini` marker definitions and docstrings describing entry points.
+- Add profiling recipes (e.g., `python -m cProfile`, `pyinstrument`) for the most critical code paths with instructions stored under `docs/` or `tests/performance/` and ready-to-run `uv run` commands.
 - Document the three-tier cadence (fast CI <5 min, medium local 5–20 min, long-haul >1 h manual) and how to record results in PRs, task briefs, or weekly progress reports.
 
 ### Out of scope
@@ -25,20 +25,22 @@ After the geometry module restructure (Task 2025-10-04-geometry-module-refactor)
 - New or updated tests ensuring algorithm variants agree on known fixtures and invariants.
 - Benchmark suite organised with pytest markers and README guidance.
 - Profiling how-to notes and scripts for the highest-priority modules.
-- Documentation (could live alongside the benchmark README) explaining cadence expectations and where to log long-haul runs (task brief updates or progress reports).
+- Documentation (could live alongside the benchmark README) explaining cadence expectations, how to invoke tiers via `make`/`pytest`/`uv run`, and where to log long-haul runs (task brief updates or progress reports).
 
 ## 4. Dependencies and prerequisites
 - Completion of geometry module restructure (Task 2025-10-04-geometry-module-refactor) or a stable branch exposing reference/optimised/JAX variants.
 - Access to curated fixtures delivered by the restructure task.
 - Agreement on benchmark runtime targets (CI <5 min, deep local <20 min, long-haul manual) per evaluation methodology.
+- Availability (or planned addition) of `pytest-benchmark` and profiling dependencies in `pyproject.toml`; escalate if missing.
 
 ## 5. Execution plan and checkpoints
 1. **Fixture audit**: confirm the restructured modules expose canonical sample polytopes/volumes.
-2. **Unit test sweep**: write or adapt tests that exercise each implementation variant side-by-side.
-3. **Benchmark scaffolding**: create pytest benchmark modules, mark tiers, and ensure smoke tier runs within CI budget.
-4. **Profiling recipes**: draft scripts/notebooks for deeper inspection, capturing instructions in docs.
-5. **Documentation pass**: update README or docs with cadence guidance and instructions for reporting results.
-6. **Validation**: run `make ci` plus the deep benchmark tier locally; spot-check long-haul instructions by running at least one sample invocation for 5–10 minutes.
+2. **Unit test sweep**: write or adapt tests that exercise each implementation variant side-by-side and register them with the new pytest markers.
+3. **Benchmark scaffolding**: create pytest benchmark modules, mark tiers, update `pytest.ini`, and ensure the smoke tier runs within CI budget.
+4. **Makefile integration**: extend or document `make bench`/related targets so each tier is easy to invoke locally and in CI.
+5. **Profiling recipes**: draft scripts/notebooks for deeper inspection, capturing instructions in docs and verifying they run via `uv run`.
+6. **Documentation pass**: update README or docs with cadence guidance and instructions for reporting results.
+7. **Validation**: run `make ci` plus the deep benchmark tier locally; spot-check long-haul instructions by running at least one sample invocation for 5–10 minutes.
 
 ## 6. Effort and resource estimates
 - **Agent time**: Medium (≈ 1 agent-week)

--- a/docs/tasks/scheduled/2025-10-05-symplectic-invariant-regression-suite.md
+++ b/docs/tasks/scheduled/2025-10-05-symplectic-invariant-regression-suite.md
@@ -1,0 +1,91 @@
+# Task Brief — Symplectic invariants regression suite (T3)
+
+- **Status**: Scheduled
+- **Last updated**: 2025-10-06
+- **Owner / DRI**: Unassigned
+- **Related docs**: `docs/tasks/02-task-portfolio.md`, `docs/algorithm-implementation-plan.md`,
+  `docs/tasks/scheduled/2025-10-04-geometry-module-refactor.md`,
+  `docs/tasks/draft/2025-10-04-testing-benchmark-harness.md`
+
+## 1. Context and intent
+The geometry restructure (T1) and harness work (T2) unlock richer property-based
+checks, but the project still lacks a consolidated suite asserting the core
+symplectic invariants (capacity bounds, monotonicity, scaling laws). This task
+curates deterministic fixtures, codifies invariance tests spanning the new
+module layout, and produces diagnostics that downstream experiments (E1–E5) can
+trust before ingesting larger datasets.
+
+## 2. Objectives and non-goals
+
+### In scope
+- Catalogue invariants covering symplectic capacities, Reeb orbit surrogates,
+  and geometric transforms relevant to Viterbo's conjecture.
+- Implement regression tests (unit + property-style) that exercise reference,
+  optimised, and JAX variants via the harness markers.
+- Capture baseline metrics (e.g., acceptable tolerance windows, runtime) and
+  publish them next to the harness README for future comparisons.
+- Document escalation paths when invariants fail (e.g., open task, bisect) so
+  agents know how to respond.
+
+### Out of scope
+- Proving new invariants beyond existing theory; focus on codifying known ones.
+- Rewriting algorithms discovered to be incorrect—log follow-up tasks instead.
+- Exhaustive randomised fuzzing beyond a handful of deterministic seeded cases.
+
+## 3. Deliverables and exit criteria
+- New test modules under `tests/` (likely `tests/geometry/`) grouped by invariant
+  family and registered with `smoke` / `ci` / `deep` markers as appropriate.
+- Companion documentation (README or section inside the harness brief) listing
+  covered invariants, tolerances, and how to interpret failures.
+- Baseline artefacts (JSON/YAML) storing expected numeric ranges for quick diff
+  during regression triage.
+
+## 4. Dependencies and prerequisites
+- Completion of T1 restructure (quantity-first modules available).
+- Maintainer review complete; execute once T1/T2 prerequisites land.
+- Availability of harness markers and fixtures from T2; collaborate if both run
+  in parallel.
+- Consensus on invariant list (can start from algorithm implementation plan and
+  maintainer guidance).
+
+## 5. Execution plan and checkpoints
+1. **Invariant inventory**: gather authoritative statements from docs and
+   existing tests; confirm with maintainer if ambiguity arises.
+2. **Fixture curation**: select canonical polytopes (simplex, cube, stretched
+   variants) and ensure deterministic reproduction.
+3. **Test implementation**: add regression/property tests wired into pytest
+   markers; capture tolerances and failure messaging.
+4. **Baseline recording**: snapshot expected metrics (e.g., capacity ratios) and
+   store them alongside the tests for diffing.
+5. **Documentation pass**: update harness README/task briefs with invariant
+   coverage and escalation steps.
+6. **Validation**: run `make ci` plus deep marker suites to ensure stability and
+   record runtimes for the portfolio.
+
+## 6. Effort and resource estimates
+- **Agent time**: Medium (≈ 1 agent-week)
+- **Compute budget**: Low to Medium (property tests + deep markers)
+- **Expert/PI involvement**: Medium (confirm invariant list, interpret issues)
+
+## 7. Testing, benchmarks, and verification
+- CI: ensure smoke/CI markers run within budgets; add targeted invariance tests
+  to GitHub Actions once stable.
+- Local: execute deep marker suite before landing substantial geometry changes.
+- Manual: when invariants fail, document reproduction steps and open follow-up
+  tasks per escalation guidance.
+
+## 8. Risks, mitigations, and escalation triggers
+- **Risk**: Some invariants depend on not-yet-implemented algorithms. **Mitigation**:
+  mark with TODO + follow-up task and guard tests with fixtures checking availability.
+- **Risk**: Tolerances too tight for floating-point drift. **Mitigation**: start
+  with conservative bounds, review with maintainer, and tighten iteratively.
+- **Escalation triggers**: Missing theoretical clarity on an invariant, inability
+  to stabilise tests within runtime budgets, or detection of discrepancies across
+  implementations.
+
+## 9. Follow-on work
+- Feed verified invariants into dataset generation (E1) and subsequent analyses
+  (E2–E5).
+- Future task to automate invariant reports (trend charts) if drift monitoring
+  becomes recurring.
+


### PR DESCRIPTION
## Summary
- move the symplectic invariants regression suite brief to scheduled after maintainer review
- note readiness dependencies so execution waits on T1/T2 landing
- update the portfolio snapshot to reference the scheduled brief

## Testing
- not run (docs-only)


------
https://chatgpt.com/codex/tasks/task_e_68e1571ea85c832bb924d9f63ed9df9a