### PR TITLE
Ensure JAX 64-bit precision and fix Ruff jaxtyping errors

### DIFF
--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 echo "[post-start] Container started."
 
+export JAX_ENABLE_X64=1
+
 HIST_DIR="$HOME/.bash_history_dir"
 HIST_FILE="$HIST_DIR/.bash_history"
 mkdir -p "$HIST_DIR" && touch "$HIST_FILE"
@@ -18,6 +20,14 @@ if ! grep -qE 'HISTFILE=.*\\.bash_history_dir/.bash_history' "$HOME/.bashrc" 2>/
     echo ''
     echo '# Persist bash history to mounted volume'
     echo 'export HISTFILE="$HOME/.bash_history_dir/.bash_history"'
+  } >> "$HOME/.bashrc"
+fi
+
+if ! grep -q 'export JAX_ENABLE_X64=1' "$HOME/.bashrc" 2>/dev/null; then
+  {
+    echo ''
+    echo '# Enable 64-bit precision for JAX by default'
+    echo 'export JAX_ENABLE_X64=1'
   } >> "$HOME/.bashrc"
 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Every task brief should include: scope, acceptance criteria, links to context (f
 - **Type checking policy**: Strict with zero silent waivers. Inline suppressions require a one-line justification and a TODO to remove.
 - **Docs**: Google docstring style (fact). All public functions/classes carry Google-style docstrings. Include shape tokens from the vocabulary for all array args/returns. Prefer Google docstrings for internal helpers as well; tiny local helpers or throwaway closures can omit. Examples only when they add clarity.
 - **Arrays & shapes**: **jaxtyping** for explicit shapes/dtypes. **No custom array typedefs** (no `Vector`, `FloatMatrix`, etc.). Prefer semantic shape names (`"num_facets"`, `"dimension"`, `"num_polytopes"`).
+- **Ruff + jaxtyping quirk**: Add a leading space inside jaxtyping shape strings (e.g., `Float[np.ndarray, " dimension"]`) so Ruff does not emit false-positive `F821` diagnostics for single tokens. This whitespace convention is required across the codebase.
 - **Dtypes**: Default to **float64** for numeric stability unless a function clearly documents another dtype.
 - **Functional core**: Math code is **pure** (no I/O, no hidden state). Side-effects live in thin adapters (imperative shell).
 - **Errors**: Fail fast with precise exceptions (`ValueError`, `TypeError`). Do not silently coerce incompatible shapes/dtypes.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 UV ?= uv
+JAX_ENABLE_X64 ?= 1
+export JAX_ENABLE_X64
 
 .PHONY: help setup format lint typecheck test bench profile profile-line ci clean
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ ignore = [
     "D203",  # let formatter manage blank lines before class definitions
     "D212",  # allow summary on second line for multi-line docstrings
 ]
+typing-modules = ["jaxtyping"]
+future-annotations = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["D"]

--- a/src/viterbo/geometry/halfspaces/_shared.py
+++ b/src/viterbo/geometry/halfspaces/_shared.py
@@ -7,9 +7,9 @@ from jaxtyping import Float
 
 
 def validate_halfspace_data(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
-) -> tuple[Float[np.ndarray, "num_facets dimension"], Float[np.ndarray, "num_facets"]]:
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
+) -> tuple[Float[np.ndarray, " num_facets dimension"], Float[np.ndarray, " num_facets"]]:
     """Validate and normalize half-space inputs."""
     matrix = np.asarray(B, dtype=float)
     offsets = np.asarray(c, dtype=float)
@@ -26,10 +26,10 @@ def validate_halfspace_data(
 
 
 def unique_rows(
-    points: Float[np.ndarray, "num_points dimension"],
+    points: Float[np.ndarray, " num_points dimension"],
     *,
     atol: float,
-) -> Float[np.ndarray, "num_unique dimension"]:
+) -> Float[np.ndarray, " num_unique dimension"]:
     """Deduplicate stacked vectors using an infinity-norm tolerance."""
     if points.size == 0:
         return points
@@ -49,12 +49,12 @@ def unique_rows(
 
 
 def deduplicate_facets(
-    matrix: Float[np.ndarray, "num_facets dimension"],
-    offsets: Float[np.ndarray, "num_facets"],
+    matrix: Float[np.ndarray, " num_facets dimension"],
+    offsets: Float[np.ndarray, " num_facets"],
     *,
     atol: float,
 ) -> tuple[
-    Float[np.ndarray, "num_unique_facets dimension"], Float[np.ndarray, "num_unique_facets"]
+    Float[np.ndarray, " num_unique_facets dimension"], Float[np.ndarray, " num_unique_facets"]
 ]:
     """Remove near-duplicate facet rows with shared offsets."""
     keep: list[int] = []

--- a/src/viterbo/geometry/halfspaces/jax.py
+++ b/src/viterbo/geometry/halfspaces/jax.py
@@ -27,11 +27,11 @@ def _solve_subset(
 
 
 def enumerate_vertices(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
-) -> Float[np.ndarray, "num_vertices dimension"]:
+) -> Float[np.ndarray, " num_vertices dimension"]:
     """Enumerate vertices using ``jax.numpy`` linear algebra."""
     matrix, offsets = _shared.validate_halfspace_data(B, c)
     num_facets, dimension = matrix.shape
@@ -66,11 +66,11 @@ def enumerate_vertices(
 
 
 def remove_redundant_facets(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
-) -> tuple[Float[np.ndarray, "num_facets dimension"], Float[np.ndarray, "num_facets"]]:
+) -> tuple[Float[np.ndarray, " num_facets dimension"], Float[np.ndarray, " num_facets"]]:
     """Prune redundant inequalities with JAX-powered solves."""
     matrix, offsets = _shared.validate_halfspace_data(B, c)
     matrix, offsets = _shared.deduplicate_facets(matrix, offsets, atol=atol)

--- a/src/viterbo/geometry/halfspaces/optimized.py
+++ b/src/viterbo/geometry/halfspaces/optimized.py
@@ -12,11 +12,11 @@ from viterbo.geometry.halfspaces import _shared
 
 
 def enumerate_vertices(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
-) -> Float[np.ndarray, "num_vertices dimension"]:
+) -> Float[np.ndarray, " num_vertices dimension"]:
     """Vectorised variant that caches feasibility checks."""
     matrix, offsets = _shared.validate_halfspace_data(B, c)
     num_facets, dimension = matrix.shape
@@ -61,11 +61,11 @@ def enumerate_vertices(
 
 
 def remove_redundant_facets(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
-) -> tuple[Float[np.ndarray, "num_facets dimension"], Float[np.ndarray, "num_facets"]]:
+) -> tuple[Float[np.ndarray, " num_facets dimension"], Float[np.ndarray, " num_facets"]]:
     """Vectorised redundancy pruning using matrix operations."""
     matrix, offsets = _shared.validate_halfspace_data(B, c)
     matrix, offsets = _shared.deduplicate_facets(matrix, offsets, atol=atol)

--- a/src/viterbo/geometry/halfspaces/reference.py
+++ b/src/viterbo/geometry/halfspaces/reference.py
@@ -12,11 +12,11 @@ from viterbo.geometry.halfspaces import _shared
 
 
 def enumerate_vertices(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
-) -> Float[np.ndarray, "num_vertices dimension"]:
+) -> Float[np.ndarray, " num_vertices dimension"]:
     """Enumerate vertices of a bounded polytope ``{x | Bx ≤ c}``."""
     matrix, offsets = _shared.validate_halfspace_data(B, c)
     num_facets, dimension = matrix.shape
@@ -52,11 +52,11 @@ def enumerate_vertices(
 
 
 def remove_redundant_facets(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
-) -> tuple[Float[np.ndarray, "num_facets dimension"], Float[np.ndarray, "num_facets"]]:
+) -> tuple[Float[np.ndarray, " num_facets dimension"], Float[np.ndarray, " num_facets"]]:
     """Prune redundant inequalities from a half-space description."""
     matrix, offsets = _shared.validate_halfspace_data(B, c)
     matrix, offsets = _shared.deduplicate_facets(matrix, offsets, atol=atol)

--- a/src/viterbo/geometry/halfspaces/samples.py
+++ b/src/viterbo/geometry/halfspaces/samples.py
@@ -8,7 +8,7 @@ from jaxtyping import Float
 
 def unit_hypercube_halfspaces(
     dimension: int,
-) -> tuple[Float[np.ndarray, "num_facets dimension"], Float[np.ndarray, "num_facets"]]:
+) -> tuple[Float[np.ndarray, " num_facets dimension"], Float[np.ndarray, " num_facets"]]:
     """Return ``Bx ≤ c`` for the axis-aligned unit hypercube centered at the origin."""
     if dimension <= 0:
         msg = "dimension must be positive"
@@ -21,8 +21,8 @@ def unit_hypercube_halfspaces(
 
 
 def unit_square_halfspaces() -> tuple[
-    Float[np.ndarray, "num_facets dimension"],
-    Float[np.ndarray, "num_facets"],
+    Float[np.ndarray, " num_facets dimension"],
+    Float[np.ndarray, " num_facets"],
 ]:
     """Return a cached 2D unit square description for convenience."""
     return unit_hypercube_halfspaces(2)

--- a/src/viterbo/geometry/polytopes/_shared.py
+++ b/src/viterbo/geometry/polytopes/_shared.py
@@ -28,7 +28,7 @@ class NormalCone:
 
     vertex: Float[np.ndarray, _DIMENSION_AXIS]
     active_facets: tuple[int, ...]
-    normals: Float[np.ndarray, "num_active dimension"]
+    normals: Float[np.ndarray, " num_active dimension"]
 
     def __post_init__(self) -> None:
         """Normalise arrays describing the normal cone."""

--- a/src/viterbo/geometry/polytopes/reference.py
+++ b/src/viterbo/geometry/polytopes/reference.py
@@ -32,24 +32,23 @@ PolytopeCombinatorics = _shared.PolytopeCombinatorics
 clear_polytope_cache = _shared.clear_polytope_cache
 polytope_fingerprint = _shared.polytope_fingerprint
 
-
 def vertices_from_halfspaces(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
-) -> Float[np.ndarray, "num_vertices dimension"]:
+) -> Float[np.ndarray, " num_vertices dimension"]:
     """Enumerate the vertices of a polytope described by ``Bx <= c``."""
     return enumerate_vertices(B, c, atol=atol)
 
 
 def halfspaces_from_vertices(
-    vertices: Float[np.ndarray, "num_vertices dimension"],
+    vertices: Float[np.ndarray, " num_vertices dimension"],
     *,
     qhull_options: str | None = None,
 ) -> tuple[
-    Float[np.ndarray, "num_facets dimension"],
-    Float[np.ndarray, "num_facets"],
+    Float[np.ndarray, " num_facets dimension"],
+    Float[np.ndarray, " num_facets"],
 ]:
     """Return a half-space description from a vertex set using Qhull."""
     hull = ConvexHull(np.asarray(vertices, dtype=float), qhull_options=qhull_options)
@@ -122,9 +121,9 @@ def cartesian_product(
 
 def affine_transform(
     polytope: Polytope,
-    matrix: Float[np.ndarray, "dimension dimension"],
+    matrix: Float[np.ndarray, " dimension dimension"],
     *,
-    translation: Float[np.ndarray, "dimension"] | None = None,
+    translation: Float[np.ndarray, " dimension"] | None = None,
     name: str | None = None,
     description: str | None = None,
 ) -> Polytope:
@@ -169,7 +168,7 @@ def affine_transform(
 
 def translate_polytope(
     polytope: Polytope,
-    translation: Float[np.ndarray, "dimension"],
+    translation: Float[np.ndarray, " dimension"],
     *,
     name: str | None = None,
     description: str | None = None,
@@ -252,8 +251,8 @@ def random_affine_map(
     shear_scale: float = 0.25,
     translation_scale: float = 0.3,
 ) -> tuple[
-    Float[np.ndarray, "dimension dimension"],
-    Float[np.ndarray, "dimension"],
+    Float[np.ndarray, " dimension dimension"],
+    Float[np.ndarray, " dimension"],
 ]:
     """Sample a well-conditioned random affine map for deterministic experiments."""
     lower, upper = scale_range
@@ -610,8 +609,8 @@ def random_transformations(
     shear_scale: float = 0.25,
 ) -> list[
     tuple[
-        Float[np.ndarray, "num_facets dimension"],
-        Float[np.ndarray, "num_facets"],
+        Float[np.ndarray, " num_facets dimension"],
+        Float[np.ndarray, " num_facets"],
     ]
 ]:
     """Generate random linear transformations and translations of ``polytope``."""

--- a/src/viterbo/geometry/volume/_shared.py
+++ b/src/viterbo/geometry/volume/_shared.py
@@ -9,7 +9,7 @@ from jaxtyping import Float
 
 
 def volume_of_simplices(
-    simplex_vertices: Float[np.ndarray, "num_simplices vertices dimension"],
+    simplex_vertices: Float[np.ndarray, " num_simplices vertices dimension"],
 ) -> float:
     """Return the total volume of stacked simplices."""
     base = simplex_vertices[:, 0, :]

--- a/src/viterbo/geometry/volume/jax.py
+++ b/src/viterbo/geometry/volume/jax.py
@@ -19,8 +19,8 @@ os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 
 def polytope_volume(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
 ) -> float:

--- a/src/viterbo/geometry/volume/optimized.py
+++ b/src/viterbo/geometry/volume/optimized.py
@@ -15,8 +15,8 @@ QhullError = _spatial.QhullError
 
 
 def polytope_volume(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
 ) -> float:

--- a/src/viterbo/geometry/volume/reference.py
+++ b/src/viterbo/geometry/volume/reference.py
@@ -12,8 +12,8 @@ ConvexHull = _spatial.ConvexHull
 
 
 def polytope_volume(
-    B: Float[np.ndarray, "num_facets dimension"],
-    c: Float[np.ndarray, "num_facets"],
+    B: Float[np.ndarray, " num_facets dimension"],
+    c: Float[np.ndarray, " num_facets"],
     *,
     atol: float = 1e-9,
 ) -> float:

--- a/src/viterbo/geometry/volume/samples.py
+++ b/src/viterbo/geometry/volume/samples.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from jaxtyping import Float
 import numpy as np
+from jaxtyping import Float
 
 from viterbo.geometry.halfspaces import samples as halfspace_samples
 
@@ -12,7 +12,9 @@ def hypercube_volume_inputs(
     dimension: int,
     *,
     radius: float = 1.0,
-) -> tuple[Float[np.ndarray, "num_facets dimension"], Float[np.ndarray, "num_facets"], float]:
+) -> tuple[
+    Float[np.ndarray, " num_facets dimension"], Float[np.ndarray, " num_facets"], float
+]:
     """Return scaled hypercube ``(B, c, volume)`` triples for regression tests."""
     matrix, offsets = halfspace_samples.unit_hypercube_halfspaces(dimension)
     scaled_matrix = matrix.copy()


### PR DESCRIPTION
## Summary
- export JAX_ENABLE_X64 by default for both the Makefile targets and VS Code devcontainer sessions
- adopt the leading-whitespace jaxtyping convention (documented in AGENTS.md) to avoid Ruff F821 false positives, replacing the TYPE_CHECKING shim per astral-sh/ruff#17386
- enable Ruff typing modules for jaxtyping to avoid false positives

## Testing
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e1884fd8ec832ba32ff675f6e8509b