### PR TITLE
refactor: strengthen solvers and geometry infrastructure

### DIFF
--- a/scripts/profile_ehz.py
+++ b/scripts/profile_ehz.py
@@ -99,7 +99,8 @@ def _build_dataset(
         dataset.append((poly.name, B, c))
         if transforms:
             variants = random_transformations(poly, rng=rng, count=transforms)
-            for index, (variant_B, variant_c) in enumerate(variants):
+            for index, variant in enumerate(variants):
+                variant_B, variant_c = variant.halfspace_data()
                 label = f"{poly.name}-variant-{index}"
                 dataset.append((label, variant_B, variant_c))
     return dataset

--- a/src/viterbo/geometry/polytopes/reference.py
+++ b/src/viterbo/geometry/polytopes/reference.py
@@ -125,6 +125,7 @@ def affine_transform(
     matrix: Float[np.ndarray, "dimension dimension"],
     *,
     translation: Float[np.ndarray, "dimension"] | None = None,
+    matrix_inverse: Float[np.ndarray, "dimension dimension"] | None = None,
     name: str | None = None,
     description: str | None = None,
 ) -> Polytope:
@@ -133,17 +134,33 @@ def affine_transform(
 
     For ``y = A x + t`` with invertible ``A``, the transformed inequality system is
     ``B' y \le c'`` where ``B' = B A^{-1}`` and ``c' = c + B' t``.
+
+    Args:
+      matrix: Linear component ``A``.
+      translation: Optional translation ``t``.
+      matrix_inverse: Optional precomputed inverse of ``matrix``. When provided
+        the inverse is validated and reused instead of recomputing it.
     """
     matrix = np.asarray(matrix, dtype=float)
     if matrix.shape != (polytope.dimension, polytope.dimension):
         msg = "Linear transform must match the ambient dimension."
         raise ValueError(msg)
 
-    try:
-        matrix_inv = np.linalg.inv(matrix)
-    except np.linalg.LinAlgError as exc:
-        msg = "Affine transform requires an invertible matrix."
-        raise ValueError(msg) from exc
+    if matrix_inverse is None:
+        try:
+            matrix_inv = np.linalg.inv(matrix)
+        except np.linalg.LinAlgError as exc:
+            msg = "Affine transform requires an invertible matrix."
+            raise ValueError(msg) from exc
+    else:
+        matrix_inv = np.asarray(matrix_inverse, dtype=float)
+        if matrix_inv.shape != (polytope.dimension, polytope.dimension):
+            msg = "Matrix inverse must match the ambient dimension."
+            raise ValueError(msg)
+
+        if not np.allclose(matrix @ matrix_inv, np.eye(polytope.dimension), atol=1e-9):
+            msg = "Provided matrix_inverse is not a valid inverse of matrix."
+            raise ValueError(msg)
 
     translation_vec = (
         np.zeros(polytope.dimension)
@@ -337,7 +354,11 @@ def random_polytope(
             description=poly_description,
         )
 
-    msg = "Failed to generate a bounded random polytope."
+    msg = (
+        "Failed to generate a bounded random polytope after "
+        f"{max_attempts} attempts (dimension={dimension}, facets={facets}, "
+        f"offset_range={offset_range}, translation_scale={translation_scale})."
+    )
     raise RuntimeError(msg)
 
 
@@ -608,14 +629,9 @@ def random_transformations(
     scale_range: tuple[float, float] = (0.6, 1.4),
     translation_scale: float = 0.3,
     shear_scale: float = 0.25,
-) -> list[
-    tuple[
-        Float[np.ndarray, "num_facets dimension"],
-        Float[np.ndarray, "num_facets"],
-    ]
-]:
-    """Generate random linear transformations and translations of ``polytope``."""
-    results: list[tuple[np.ndarray, np.ndarray]] = []
+) -> list[Polytope]:
+    """Generate random affine images of ``polytope``."""
+    results: list[Polytope] = []
     for _ in range(count):
         matrix, translation = random_affine_map(
             polytope.dimension,
@@ -631,7 +647,7 @@ def random_transformations(
             name=f"{polytope.name}-random",
             description=f"Random affine perturbation of {polytope.name}",
         )
-        results.append(transformed.halfspace_data())
+        results.append(transformed)
     return results
 
 

--- a/src/viterbo/geometry/volume/jax.py
+++ b/src/viterbo/geometry/volume/jax.py
@@ -2,20 +2,56 @@
 
 from __future__ import annotations
 
-import os
+import importlib
+from functools import lru_cache
+from typing import Protocol, cast
 
 import numpy as np
-import scipy.spatial as _spatial  # type: ignore[reportMissingTypeStubs]
 from jaxtyping import Float
 
 from viterbo.geometry.halfspaces import jax as halfspaces_jax
 from viterbo.geometry.volume import _shared
 
-ConvexHull = _spatial.ConvexHull
-Delaunay = _spatial.Delaunay
-QhullError = _spatial.QhullError
 
-os.environ.setdefault("JAX_ENABLE_X64", "1")
+class _ConvexHullResult(Protocol):
+    volume: float
+
+
+class _DelaunayResult(Protocol):
+    simplices: np.ndarray
+
+
+class _ConvexHullFactory(Protocol):
+    def __call__(
+        self,
+        points: np.ndarray,
+        *,
+        qhull_options: str | None = ...,  # noqa: D401 - see implementation docs
+    ) -> _ConvexHullResult:
+        """Return the convex hull of ``points``."""
+        ...
+
+
+class _DelaunayFactory(Protocol):
+    def __call__(
+        self,
+        points: np.ndarray,
+        *,
+        qhull_options: str | None = ...,  # noqa: D401 - see implementation docs
+    ) -> _DelaunayResult:
+        """Return the Delaunay triangulation of ``points``."""
+        ...
+
+
+@lru_cache(1)
+def _load_spatial() -> tuple[_ConvexHullFactory, _DelaunayFactory, type[Exception]]:
+    """Return SciPy spatial factories with static typing."""
+
+    spatial = importlib.import_module("scipy.spatial")
+    convex_hull = cast(_ConvexHullFactory, getattr(spatial, "ConvexHull"))
+    delaunay = cast(_DelaunayFactory, getattr(spatial, "Delaunay"))
+    qhull_error = cast(type[Exception], getattr(spatial, "QhullError"))
+    return convex_hull, delaunay, qhull_error
 
 
 def polytope_volume(
@@ -32,10 +68,12 @@ def polytope_volume(
         msg = "No vertices found; polytope may be empty or unbounded."
         raise ValueError(msg)
 
+    convex_hull, delaunay, qhull_error = _load_spatial()
+
     try:
-        triangulation = Delaunay(vertices_np, qhull_options="QJ")
-    except QhullError:
-        hull = ConvexHull(vertices_np, qhull_options="QJ")
+        triangulation = delaunay(vertices_np, qhull_options="QJ")
+    except qhull_error:
+        hull = convex_hull(vertices_np, qhull_options="QJ")
         return float(hull.volume)
 
     simplices = vertices_np[triangulation.simplices]

--- a/src/viterbo/symplectic/capacity_algorithms/_subset_utils.py
+++ b/src/viterbo/symplectic/capacity_algorithms/_subset_utils.py
@@ -1,0 +1,151 @@
+"""Shared helpers for facet-subset preparation across EHZ solvers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Final
+
+import numpy as np
+from jaxtyping import Float
+
+_DIMENSION_AXIS: Final[str] = "dimension"
+_FACET_AXIS: Final[str] = "num_facets"
+_M_AXIS: Final[str] = "m"
+
+
+@dataclass(frozen=True)
+class FacetSubset:
+    """Data describing a subset of polytope facets."""
+
+    indices: tuple[int, ...]
+    beta: Float[np.ndarray, f"{_M_AXIS}"]  # shape: (m,)
+    symplectic_products: Float[np.ndarray, f"{_M_AXIS} {_M_AXIS}"]  # shape: (m, m)
+
+
+def iter_index_combinations(count: int, size: int) -> Iterator[tuple[int, ...]]:
+    """Yield index tuples of length ``size`` drawn from ``count`` facets."""
+
+    for combination in combinations(range(count), size):
+        yield tuple(int(index) for index in combination)
+
+
+def prepare_subset(
+    *,
+    B_matrix: Float[np.ndarray, f"{_FACET_AXIS} {_DIMENSION_AXIS}"],
+    c: Float[np.ndarray, _FACET_AXIS],
+    indices: Iterable[int],
+    J: np.ndarray,
+    tol: float,
+) -> FacetSubset | None:
+    """Solve the Reeb-measure system for a facet subset and cache products."""
+
+    selected_tuple = tuple(int(index) for index in indices)
+    row_indices = np.array(selected_tuple, dtype=int)
+    B_subset = B_matrix[row_indices, :]
+    c_subset = c[row_indices]
+    m = B_subset.shape[0]
+
+    system = np.zeros((m, m))
+    system[0, :] = c_subset
+    system[1:, :] = B_subset.T
+
+    rhs = np.zeros(m)
+    rhs[0] = 1.0
+
+    try:
+        beta = np.linalg.solve(system, rhs)
+    except np.linalg.LinAlgError:
+        return None
+
+    beta[np.abs(beta) <= tol] = 0.0
+    if np.any(beta < -tol):
+        return None
+
+    if not np.allclose(
+        B_subset.T @ beta,
+        np.zeros(B_subset.shape[1]),
+        atol=tol,
+        rtol=0.0,
+    ):
+        return None
+
+    if not np.isclose(float(c_subset @ beta), 1.0, atol=tol, rtol=0.0):
+        return None
+
+    symplectic_products = (B_subset @ J) @ B_subset.T
+    return FacetSubset(indices=selected_tuple, beta=beta, symplectic_products=symplectic_products)
+
+
+def maximum_antisymmetric_order_value(weights: np.ndarray) -> float:
+    r"""Return the maximum order value for an antisymmetric weight matrix."""
+
+    m = weights.shape[0]
+    if m == 0:
+        return 0.0
+
+    size = 1 << m
+    dp = np.full(size, -np.inf)
+    dp[0] = 0.0
+
+    prefix_sums = np.zeros((m, size))
+    for idx in range(m):
+        for mask in range(1, size):
+            lsb = mask & -mask
+            bit_index = lsb.bit_length() - 1
+            prev_mask = mask ^ lsb
+            prefix_sums[idx, mask] = prefix_sums[idx, prev_mask] + weights[idx, bit_index]
+
+    for mask in range(size):
+        current = dp[mask]
+        if not np.isfinite(current):
+            continue
+
+        remaining = (~mask) & (size - 1)
+        while remaining:
+            lsb = remaining & -remaining
+            next_index = lsb.bit_length() - 1
+            new_mask = mask | lsb
+            candidate = current + prefix_sums[next_index, mask]
+            if candidate > dp[new_mask]:
+                dp[new_mask] = candidate
+            remaining ^= lsb
+
+    return float(dp[-1])
+
+
+def subset_capacity_candidate_dynamic(
+    subset: FacetSubset,
+    *,
+    tol: float,
+) -> float | None:
+    """Return the candidate capacity using the dynamic-programming shortcut."""
+
+    beta = subset.beta
+    symplectic_products = subset.symplectic_products
+
+    positive = np.where(beta > tol)[0]
+    if positive.size < 2:
+        return None
+
+    beta_active = beta[positive]
+    W_active = symplectic_products[np.ix_(positive, positive)]
+    weights = np.multiply.outer(beta_active, beta_active) * W_active
+
+    np.fill_diagonal(weights, 0.0)
+
+    maximal_value = maximum_antisymmetric_order_value(weights)
+    if maximal_value <= tol:
+        return None
+
+    return 0.5 / maximal_value
+
+
+__all__ = [
+    "FacetSubset",
+    "iter_index_combinations",
+    "maximum_antisymmetric_order_value",
+    "prepare_subset",
+    "subset_capacity_candidate_dynamic",
+]

--- a/tests/geometry/_polytope_samples.py
+++ b/tests/geometry/_polytope_samples.py
@@ -58,7 +58,8 @@ def load_polytope_instances(
             )
 
         variants = random_transformations(polytope, rng=rng, count=variant_count)
-        for index, (variant_B, variant_c) in enumerate(variants):
+        for index, variant in enumerate(variants):
+            variant_B, variant_c = variant.halfspace_data()
             instances.append((variant_B, variant_c))
             identifiers.append(f"{polytope.name}-variant-{index}")
             if include_metadata:

--- a/tests/symplectic/test_ehz_capacity_fast.py
+++ b/tests/symplectic/test_ehz_capacity_fast.py
@@ -9,8 +9,10 @@ import pytest
 
 from tests.geometry._polytope_samples import load_polytope_instances
 from viterbo.symplectic.capacity import compute_ehz_capacity
+from viterbo.symplectic.capacity_algorithms._subset_utils import (
+    maximum_antisymmetric_order_value,
+)
 from viterbo.symplectic.capacity_algorithms.facet_normals_fast import (
-    _maximum_antisymmetric_order_value,  # type: ignore[reportPrivateUsage]  # Internal test of private helper; TODO: expose via public API
     compute_ehz_capacity_fast,
 )
 
@@ -30,7 +32,7 @@ def test_dynamic_program_matches_bruteforce() -> None:
                 total += weights[idx_i, idx_j]
         brute = max(brute, total)
 
-    dp_value = _maximum_antisymmetric_order_value(weights)
+    dp_value = maximum_antisymmetric_order_value(weights)
     assert np.isclose(dp_value, brute, atol=1e-12)
 
 


### PR DESCRIPTION
## Summary
- extract shared facet subset utilities for the facet-normal EHZ solvers, removing private cross-imports and guarding the reference implementation with the dynamic-programming fallback
- harden the linear-program solver wrapper by normalising bounds, surfacing SciPy failures, and improving polytope helpers (thread-safe cache keys, richer random transforms, better search iteration)
- drop import-time JAX side effects by lazily configuring jax.numpy and wrapping SciPy spatial factories, updating tests and scripts to the new APIs
- convert the tolerance propagation regression test to use a dedicated fixture instead of ad-hoc monkeypatching

## Testing
- uv run pyright
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e188d6750c832bbcb3e9d0f280f0d4