### PR TITLE
fix: resolve lint fallout from merges

### DIFF
--- a/src/viterbo/geometry/halfspaces/jax.py
+++ b/src/viterbo/geometry/halfspaces/jax.py
@@ -2,32 +2,23 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
 from itertools import combinations
-from typing import Any, Iterator, Sequence, cast
+from typing import Iterator, Sequence
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Float
 
 from viterbo.geometry.halfspaces import _shared
 
-
-@lru_cache(1)
-def _jax_numpy() -> Any:
-    """Return ``jax.numpy`` with 64-bit mode enabled."""
-
-    import jax
-
-    config = cast(Any, jax.config)
-    config.update("jax_enable_x64", True)
-    import jax.numpy as jnp_mod
-
-    return jnp_mod
+if not bool(jax.config.read("jax_enable_x64")):
+    msg = "JAX 64-bit mode must be enabled; set JAX_ENABLE_X64=1."
+    raise RuntimeError(msg)
 
 
 def _iter_index_combinations(count: int, dimension: int) -> Iterator[tuple[int, ...]]:
     """Yield index combinations for ``dimension`` facets."""
-
     for combination in combinations(range(count), dimension):
         yield tuple(int(index) for index in combination)
 
@@ -39,7 +30,6 @@ def _solve_subset(
 ) -> np.ndarray:
     subset = matrix[list(indices), :].astype(np.float64, copy=False)
     subset_offsets = offsets[list(indices)].astype(np.float64, copy=False)
-    jnp = _jax_numpy()
     return np.asarray(jnp.linalg.solve(subset, subset_offsets), dtype=float)
 
 

--- a/src/viterbo/geometry/polytopes/_shared.py
+++ b/src/viterbo/geometry/polytopes/_shared.py
@@ -156,13 +156,11 @@ def polytope_fingerprint(polytope: Polytope, *, decimals: int = 12) -> str:
 
 def _tolerance_fingerprint(atol: float) -> str:
     """Return a deterministic fingerprint for ``atol``."""
-
     return struct.pack("!d", float(atol)).hex()
 
 
 def polytope_cache_key(polytope: Polytope, atol: float) -> tuple[str, str]:
     """Return the cache key used for combinatorics lookups."""
-
     return polytope_fingerprint(polytope), _tolerance_fingerprint(atol)
 
 

--- a/src/viterbo/geometry/polytopes/reference.py
+++ b/src/viterbo/geometry/polytopes/reference.py
@@ -135,10 +135,14 @@ def affine_transform(
     ``B' y \le c'`` where ``B' = B A^{-1}`` and ``c' = c + B' t``.
 
     Args:
+      polytope: Polytope to transform. Must expose ``dimension`` matching ``matrix``.
       matrix: Linear component ``A``.
       translation: Optional translation ``t``.
       matrix_inverse: Optional precomputed inverse of ``matrix``. When provided
         the inverse is validated and reused instead of recomputing it.
+      name: Optional override for the transformed polytope's name. Defaults to
+        ``"{polytope.name}-affine"`` when not provided.
+      description: Optional textual description for the transformed polytope.
     """
     matrix = np.asarray(matrix, dtype=float)
     if matrix.shape != (polytope.dimension, polytope.dimension):

--- a/src/viterbo/geometry/volume/jax.py
+++ b/src/viterbo/geometry/volume/jax.py
@@ -46,11 +46,10 @@ class _DelaunayFactory(Protocol):
 @lru_cache(1)
 def _load_spatial() -> tuple[_ConvexHullFactory, _DelaunayFactory, type[Exception]]:
     """Return SciPy spatial factories with static typing."""
-
     spatial = importlib.import_module("scipy.spatial")
-    convex_hull = cast(_ConvexHullFactory, getattr(spatial, "ConvexHull"))
-    delaunay = cast(_DelaunayFactory, getattr(spatial, "Delaunay"))
-    qhull_error = cast(type[Exception], getattr(spatial, "QhullError"))
+    convex_hull = cast(_ConvexHullFactory, spatial.ConvexHull)
+    delaunay = cast(_DelaunayFactory, spatial.Delaunay)
+    qhull_error = cast(type[Exception], spatial.QhullError)
     return convex_hull, delaunay, qhull_error
 
 

--- a/src/viterbo/optimization/search.py
+++ b/src/viterbo/optimization/search.py
@@ -94,9 +94,12 @@ def enumerate_search_space(
     """Return a deterministic tuple of polytopes spanning diverse geometries.
 
     Args:
+      rng_seed: Seed controlling the pseudo-random search components.
+      max_dimension: Maximum ambient dimension for enumerated polytopes.
+      transforms_per_base: Number of affine transforms applied to each base polytope.
+      random_polytopes_per_dimension: Random samples generated per dimension.
       max_candidates: Optional cap on the number of polytopes produced.
     """
-
     generator = _generate_search_space(
         rng_seed=rng_seed,
         max_dimension=max_dimension,
@@ -110,7 +113,6 @@ def enumerate_search_space(
 
 def iter_search_space(**kwargs: int) -> Iterator[Polytope]:
     """Yield polytopes from :func:`enumerate_search_space` lazily."""
-
     max_candidates = kwargs.pop("max_candidates", None)
     rng_seed = kwargs.pop("rng_seed", 7)
     max_dimension = kwargs.pop("max_dimension", 6)

--- a/src/viterbo/optimization/solvers.py
+++ b/src/viterbo/optimization/solvers.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import importlib
 from dataclasses import dataclass
 from functools import lru_cache
-import importlib
 from typing import Any, Mapping, Protocol, Sequence, TypeGuard, cast
 
 import numpy as np
@@ -47,21 +47,17 @@ class _LinprogCallable(Protocol):
 @lru_cache(1)
 def _load_linprog() -> _LinprogCallable:
     """Return the SciPy ``linprog`` callable with a static type signature."""
-
     module = importlib.import_module("scipy.optimize")
-    linprog_callable = getattr(module, "linprog")
-    return cast(_LinprogCallable, linprog_callable)
+    return cast(_LinprogCallable, module.linprog)
 
 
 def _is_bounds_object(candidate: object) -> TypeGuard[_BoundsProtocol]:
     """Return ``True`` if ``candidate`` exposes ``lb``/``ub`` arrays."""
-
     return hasattr(candidate, "lb") and hasattr(candidate, "ub")
 
 
 def _coerce_bound_value(value: float | None) -> float | None:
     """Convert ``value`` to a finite float or ``None`` for unbounded entries."""
-
     if value is None:
         return None
     numeric = float(value)
@@ -78,7 +74,6 @@ def _normalize_bounds(
     dimension: int,
 ) -> tuple[BoundTuple, ...]:
     """Validate and canonicalise ``bounds`` for SciPy's ``linprog``."""
-
     normalized: list[BoundTuple]
 
     if _is_bounds_object(bounds):

--- a/src/viterbo/symplectic/capacity_algorithms/_subset_utils.py
+++ b/src/viterbo/symplectic/capacity_algorithms/_subset_utils.py
@@ -26,7 +26,6 @@ class FacetSubset:
 
 def iter_index_combinations(count: int, size: int) -> Iterator[tuple[int, ...]]:
     """Yield index tuples of length ``size`` drawn from ``count`` facets."""
-
     for combination in combinations(range(count), size):
         yield tuple(int(index) for index in combination)
 
@@ -40,7 +39,6 @@ def prepare_subset(
     tol: float,
 ) -> FacetSubset | None:
     """Solve the Reeb-measure system for a facet subset and cache products."""
-
     selected_tuple = tuple(int(index) for index in indices)
     row_indices = np.array(selected_tuple, dtype=int)
     B_subset = B_matrix[row_indices, :]
@@ -80,7 +78,6 @@ def prepare_subset(
 
 def maximum_antisymmetric_order_value(weights: np.ndarray) -> float:
     r"""Return the maximum order value for an antisymmetric weight matrix."""
-
     m = weights.shape[0]
     if m == 0:
         return 0.0
@@ -121,7 +118,6 @@ def subset_capacity_candidate_dynamic(
     tol: float,
 ) -> float | None:
     """Return the candidate capacity using the dynamic-programming shortcut."""
-
     beta = subset.beta
     symplectic_products = subset.symplectic_products
 

--- a/tests/symplectic/test_facet_normals_algorithms.py
+++ b/tests/symplectic/test_facet_normals_algorithms.py
@@ -1,18 +1,18 @@
 """Regression tests for the facet-normal EHZ capacity algorithms."""
-
 from __future__ import annotations
 
 import math
+
 import numpy as np
 import pytest
 from pytest import MonkeyPatch
 
 from tests.geometry._polytope_samples import load_polytope_instances
+from viterbo.symplectic.capacity_algorithms import _subset_utils as subset_utils
 from viterbo.symplectic.capacity_algorithms import (
     compute_ehz_capacity_fast,
     compute_ehz_capacity_reference,
 )
-from viterbo.symplectic.capacity_algorithms import _subset_utils as subset_utils
 from viterbo.symplectic.core import standard_symplectic_matrix
 
 _BASE_DATA = load_polytope_instances(variant_count=0)
@@ -25,7 +25,6 @@ def fixture_subset_utils_close_records(
     monkeypatch: MonkeyPatch,
 ) -> dict[str, float | None]:
     """Patch ``subset_utils`` closeness helpers and capture tolerance arguments."""
-
     records: dict[str, float | None] = {
         "allclose": None,
         "allclose_rtol": None,


### PR DESCRIPTION
## Summary
- remove merge-introduced lint regressions across geometry and optimization helpers
- document missing parameters and avoid getattr indirection in SciPy adapters
- normalize test imports and docstring spacing for symplectic capacity coverage
- rely on env-provided JAX 64-bit config and fail fast if disabled in half-space helpers

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e19572e3ec832bafe045fad7ce2693