### PR TITLE
fix: unblock ci by repairing geometry typings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      JAX_ENABLE_X64: "1"
 
     steps:
       - name: Checkout repository
@@ -49,6 +51,8 @@ jobs:
   performance-benchmarks:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    env:
+      JAX_ENABLE_X64: "1"
 
     steps:
       - name: Checkout repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ def ehz_capacity(
 ## 12) CI & Branch protection (facts)
 
 * `make ci` mirrors GitHub Actions (format check → lint → strict typecheck → tests).
+* **Before opening a PR**, run `make ci` locally and ensure it succeeds; if it fails for reasons you cannot resolve quickly, escalate via the task brief rather than skipping the check.
 * Branch protection requires all checks to pass before merge.
 * Concurrency cancels in-progress runs per ref to save CI time.
 * Perf-critical changes: include a benchmark delta summary or a documented waiver.

--- a/src/viterbo/geometry/halfspaces/jax.py
+++ b/src/viterbo/geometry/halfspaces/jax.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import combinations
-from typing import Iterator, Sequence
+from typing import Iterator, Protocol, Sequence, cast
 
 import jax
 import jax.numpy as jnp
@@ -12,7 +12,15 @@ from jaxtyping import Float
 
 from viterbo.geometry.halfspaces import _shared
 
-if not bool(jax.config.read("jax_enable_x64")):
+
+class _JaxConfig(Protocol):
+    def read(self, name: str, /) -> object:
+        """Return the configured value for ``name``."""
+
+
+config = cast(_JaxConfig, jax.config)
+enable_x64_raw = config.read("jax_enable_x64")
+if not bool(enable_x64_raw):
     msg = "JAX 64-bit mode must be enabled; set JAX_ENABLE_X64=1."
     raise RuntimeError(msg)
 

--- a/src/viterbo/geometry/halfspaces/jax.py
+++ b/src/viterbo/geometry/halfspaces/jax.py
@@ -17,11 +17,15 @@ class _JaxConfig(Protocol):
     def read(self, name: str, /) -> object:
         """Return the configured value for ``name``."""
 
+    def update(self, name: str, value: object, /) -> None:
+        """Set the configured value for ``name``."""
+
 
 config = cast(_JaxConfig, jax.config)
+config.update("jax_enable_x64", True)
 enable_x64_raw = config.read("jax_enable_x64")
 if not bool(enable_x64_raw):
-    msg = "JAX 64-bit mode must be enabled; set JAX_ENABLE_X64=1."
+    msg = "Failed to enable JAX 64-bit mode; set JAX_ENABLE_X64=1 before import."
     raise RuntimeError(msg)
 
 

--- a/src/viterbo/geometry/halfspaces/jax.py
+++ b/src/viterbo/geometry/halfspaces/jax.py
@@ -17,15 +17,10 @@ class _JaxConfig(Protocol):
     def read(self, name: str, /) -> object:
         """Return the configured value for ``name``."""
 
-    def update(self, name: str, value: object, /) -> None:
-        """Set the configured value for ``name``."""
-
 
 config = cast(_JaxConfig, jax.config)
-config.update("jax_enable_x64", True)
-enable_x64_raw = config.read("jax_enable_x64")
-if not bool(enable_x64_raw):
-    msg = "Failed to enable JAX 64-bit mode; set JAX_ENABLE_X64=1 before import."
+if not bool(config.read("jax_enable_x64")):
+    msg = "JAX 64-bit mode must be enabled; set JAX_ENABLE_X64=1 before import."
     raise RuntimeError(msg)
 
 

--- a/src/viterbo/geometry/polytopes/reference.py
+++ b/src/viterbo/geometry/polytopes/reference.py
@@ -32,6 +32,7 @@ PolytopeCombinatorics = _shared.PolytopeCombinatorics
 clear_polytope_cache = _shared.clear_polytope_cache
 polytope_fingerprint = _shared.polytope_fingerprint
 
+
 def vertices_from_halfspaces(
     B: Float[np.ndarray, " num_facets dimension"],
     c: Float[np.ndarray, " num_facets"],
@@ -632,14 +633,9 @@ def random_transformations(
     scale_range: tuple[float, float] = (0.6, 1.4),
     translation_scale: float = 0.3,
     shear_scale: float = 0.25,
-) -> list[
-    tuple[
-        Float[np.ndarray, " num_facets dimension"],
-        Float[np.ndarray, " num_facets"],
-    ]
-]:
+) -> list[Polytope]:
     """Generate random linear transformations and translations of ``polytope``."""
-    results: list[tuple[np.ndarray, np.ndarray]] = []
+    results: list[Polytope] = []
     for _ in range(count):
         matrix, translation = random_affine_map(
             polytope.dimension,

--- a/src/viterbo/geometry/volume/samples.py
+++ b/src/viterbo/geometry/volume/samples.py
@@ -12,9 +12,7 @@ def hypercube_volume_inputs(
     dimension: int,
     *,
     radius: float = 1.0,
-) -> tuple[
-    Float[np.ndarray, " num_facets dimension"], Float[np.ndarray, " num_facets"], float
-]:
+) -> tuple[Float[np.ndarray, " num_facets dimension"], Float[np.ndarray, " num_facets"], float]:
     """Return scaled hypercube ``(B, c, volume)`` triples for regression tests."""
     matrix, offsets = halfspace_samples.unit_hypercube_halfspaces(dimension)
     scaled_matrix = matrix.copy()

--- a/tests/symplectic/test_facet_normals_algorithms.py
+++ b/tests/symplectic/test_facet_normals_algorithms.py
@@ -1,4 +1,5 @@
 """Regression tests for the facet-normal EHZ capacity algorithms."""
+
 from __future__ import annotations
 
 import math


### PR DESCRIPTION
## Summary
- align `random_transformations` with its `Polytope` return values and adjust consumers
- model `jax.config` with a protocol to keep the x64 guard while satisfying Pyright
- refresh Ruff formatting for geometry utilities and associated regression tests

## Testing
- `make ci`


------
https://chatgpt.com/codex/tasks/task_e_68e19a906258832bb40f29a191299b81