### PR TITLE
docs: promote T2 harness brief after T1 completion

### DIFF
--- a/docs/tasks/02-task-portfolio.md
+++ b/docs/tasks/02-task-portfolio.md
@@ -11,7 +11,7 @@ visible at a glance.
 | ID | Brief | Status | Expected utility | Cost (agent / compute / expert) | Priority | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
 | T1 | [Geometry quantity module restructure & JAX baselines](completed/2025-10-04-geometry-module-refactor.md) | Completed | **+3.15** | Medium / Low / Low | — | Root of SWE work; enables all downstream experiments. |
-| T2 | [Testing, benchmarking, and profiling harness](draft/2025-10-04-testing-benchmark-harness.md) | Draft | **+2.30** | Medium / Low / Low | 0.5 | Lands immediately after T1 to secure regression safety. |
+| T2 | [Testing, benchmarking, and profiling harness](scheduled/2025-10-04-testing-benchmark-harness.md) | Scheduled | **+2.30** | Medium / Low / Low | 0.5 | Ready to execute now that T1 fixtures shipped; secures regression safety. |
 | T3 | [Symplectic invariants regression suite](scheduled/2025-10-05-symplectic-invariant-regression-suite.md) | Scheduled | **+2.50** | Medium / Low / Medium | 0.75 | Hardens invariants before dataset work. |
 | T4 | [JAX Pyright stub integration](scheduled/2025-10-06-jax-pyright-stubs.md) | Scheduled | **+2.10** | Medium / Low / Low | 0.60 | Unlocks strict typing for JAX-backed modules. |
 | E1 | [Facet-normal validation & dataset build](draft/2025-10-04-facet-dataset.md) | Draft | **+2.70** | Medium / Low / Low | 1 | First numerical experiment; seeds data for the rest. |
@@ -53,8 +53,8 @@ Update this graph whenever briefs change status or new items enter the queue.
 - **Status**: Completed — downstream work (T2, T3) can now assume the new layout.
 
 ### T2 — Testing, benchmarking, and profiling harness
-- **Brief**: [`docs/tasks/draft/2025-10-04-testing-benchmark-harness.md`](draft/2025-10-04-testing-benchmark-harness.md)
-- **Why it matters**: secures regression safety once T1 lands, provides pytest
+- **Brief**: [`docs/tasks/scheduled/2025-10-04-testing-benchmark-harness.md`](scheduled/2025-10-04-testing-benchmark-harness.md)
+- **Why it matters**: secures regression safety now that T1 landed, provides pytest
   benchmark tiers, and documents profiling recipes aligned with the agreed
   cadence.
 - **Next checkpoint**: validate smoke benchmark runtime (<5 minutes) before

--- a/docs/tasks/draft/2025-10-04-facet-dataset.md
+++ b/docs/tasks/draft/2025-10-04-facet-dataset.md
@@ -1,7 +1,7 @@
 # Task Brief — Facet-normal validation and dataset build (E1)
 
 - **Status**: Draft
-- **Last updated**: 2025-10-04
+- **Last updated**: 2025-10-07
 - **Owner / DRI**: Unassigned
 - **Related docs**: `docs/tasks/02-task-portfolio.md`, `docs/algorithm-implementation-plan.md`
 
@@ -27,7 +27,11 @@ We aim to construct a curated dataset of polytopes, their facet normals, and der
 - Updated task brief follow-up notes or weekly progress report capturing observed patterns, potential conjectures, and flagged edge cases.
 
 ## 4. Dependencies and prerequisites
-- Completion of Tasks 2025-10-04-geometry-module-refactor and 2025-10-04-testing-benchmark-harness.
+- Completion of Task 2025-10-04-geometry-module-refactor — satisfied via the
+  [completed brief](../completed/2025-10-04-geometry-module-refactor.md).
+- Execution of Task 2025-10-04-testing-benchmark-harness
+  ([scheduled brief](../scheduled/2025-10-04-testing-benchmark-harness.md)) to lock
+  in regression coverage and benchmark markers.
 - Agreement on dataset storage location and format.
 - Benchmark cadence guidance from methodology to monitor runtime.
 

--- a/docs/tasks/scheduled/2025-10-04-testing-benchmark-harness.md
+++ b/docs/tasks/scheduled/2025-10-04-testing-benchmark-harness.md
@@ -1,12 +1,14 @@
-# Task Brief — Testing, benchmarking, and profiling harness
+# Task Brief — Testing, benchmarking, and profiling harness (T2)
 
-- **Status**: Draft
-- **Last updated**: 2025-10-05
+- **Status**: Scheduled
+- **Last updated**: 2025-10-07
 - **Owner / DRI**: Unassigned
-- **Related docs**: `docs/tasks/01-task-evaluation-methodology.md`, `docs/tasks/02-task-portfolio.md`, `docs/algorithm-implementation-plan.md`
+- **Related docs**: `docs/tasks/01-task-evaluation-methodology.md`, `docs/tasks/02-task-portfolio.md`,
+  `docs/algorithm-implementation-plan.md`,
+  `docs/tasks/completed/2025-10-04-geometry-module-refactor.md`
 
 ## 1. Context and intent
-After the geometry module restructure (Task 2025-10-04-geometry-module-refactor), we need automated verification to prevent regressions. This task establishes unit comparisons across implementation variants, codifies benchmark tiers (smoke, CI, deep, long-haul), wires profiling entry points, and ensures these hooks integrate with the existing `Makefile` + `pytest.ini` tooling so agents can reason about performance before launching computational experiments.
+After the geometry module restructure (Task 2025-10-04-geometry-module-refactor) wrapped, we need automated verification to prevent regressions. This task establishes unit comparisons across implementation variants, codifies benchmark tiers (smoke, CI, deep, long-haul), wires profiling entry points, and ensures these hooks integrate with the existing `Makefile` + `pytest.ini` tooling so agents can reason about performance before launching computational experiments.
 
 ## 2. Objectives and non-goals
 
@@ -28,13 +30,14 @@ After the geometry module restructure (Task 2025-10-04-geometry-module-refactor)
 - Documentation (could live alongside the benchmark README) explaining cadence expectations, how to invoke tiers via `make`/`pytest`/`uv run`, and where to log long-haul runs (task brief updates or progress reports).
 
 ## 4. Dependencies and prerequisites
-- Completion of geometry module restructure (Task 2025-10-04-geometry-module-refactor) or a stable branch exposing reference/optimised/JAX variants.
+- Completion of geometry module restructure (Task 2025-10-04-geometry-module-refactor) — satisfied via the
+  [completed brief](../completed/2025-10-04-geometry-module-refactor.md) and the new quantity packages.
 - Access to curated fixtures delivered by the restructure task.
 - Agreement on benchmark runtime targets (CI <5 min, deep local <20 min, long-haul manual) per evaluation methodology.
 - Availability (or planned addition) of `pytest-benchmark` and profiling dependencies in `pyproject.toml`; escalate if missing.
 
 ## 5. Execution plan and checkpoints
-1. **Fixture audit**: confirm the restructured modules expose canonical sample polytopes/volumes.
+1. **Fixture audit**: confirm the restructured modules expose canonical sample polytopes/volumes and catalogue the parity tests delivered in T1.
 2. **Unit test sweep**: write or adapt tests that exercise each implementation variant side-by-side and register them with the new pytest markers.
 3. **Benchmark scaffolding**: create pytest benchmark modules, mark tiers, update `pytest.ini`, and ensure the smoke tier runs within CI budget.
 4. **Makefile integration**: extend or document `make bench`/related targets so each tier is easy to invoke locally and in CI.

--- a/docs/tasks/scheduled/2025-10-05-symplectic-invariant-regression-suite.md
+++ b/docs/tasks/scheduled/2025-10-05-symplectic-invariant-regression-suite.md
@@ -4,8 +4,8 @@
 - **Last updated**: 2025-10-06
 - **Owner / DRI**: Unassigned
 - **Related docs**: `docs/tasks/02-task-portfolio.md`, `docs/algorithm-implementation-plan.md`,
-  `docs/tasks/scheduled/2025-10-04-geometry-module-refactor.md`,
-  `docs/tasks/draft/2025-10-04-testing-benchmark-harness.md`
+  `docs/tasks/completed/2025-10-04-geometry-module-refactor.md`,
+  `docs/tasks/scheduled/2025-10-04-testing-benchmark-harness.md`
 
 ## 1. Context and intent
 The geometry restructure (T1) and harness work (T2) unlock richer property-based


### PR DESCRIPTION
## Summary
- promote the T2 testing/benchmark harness brief to scheduled status and refresh its dependencies after T1 landed
- update the portfolio and T3 brief to link against the completed restructure documentation
- clarify the E1 dataset brief prerequisites with explicit references to the completed restructure and scheduled harness work

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1a66f8ac0832bb2c059dfce5ea8a2