### PR TITLE
fix: adopt optax stack and document solver follow-up

### DIFF
--- a/docs/algorithm-implementation-plan.md
+++ b/docs/algorithm-implementation-plan.md
@@ -30,8 +30,9 @@ Status tags: unmarked items remain in progress; entries labelled `[done]` are co
   - Use reference implementations as oracles for the fast counterparts on random polytopes in low
     dimension, and compare different algorithms where theoretical equality/ordering holds.
 - Tooling:
-  - LP: adopt a single JAX‑first path via JAXopt’s OSQP with `Q = 0` (no generic solver
-    abstraction). Keep SciPy/NumPy interop under `viterbo._wrapped/` only.
+  - LP: adopt a single JAX‑first path. JAXopt’s OSQP wrapper is deprecated, so evaluate a
+    maintained replacement before adding a new dependency; keep SciPy/NumPy interop under
+    `viterbo._wrapped/` only.
 - MILP: standardise on HiGHS via `highspy` with direct use and no abstraction. Place any interop
   code under `viterbo._wrapped/` or keep in notebooks/scripts.
   - Reuse existing half-space and vertex utilities in `viterbo.geometry.polytopes` for conversions
@@ -43,7 +44,7 @@ Status tags: unmarked items remain in progress; entries labelled `[done]` are co
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------- |
 | [done] Geometry backends       | Extend `viterbo.geometry.polytopes` with converters between H/V-representations, facet adjacency, and normal fan traversal utilities. Cache combinatorial data keyed by hashable polytope fingerprints. | `scipy`, `pycddlib` (optional)             | Unit tests covering cubes, simplices, products; deterministic hashing |
 | [done] Symplectic form helpers | Centralise symplectic matrix builders, support-function evaluations, and Minkowski sums in `viterbo.symplectic.core`.                                                                                   | `jax.numpy` (migrate from NumPy)           | Compare with closed-form values on axis-aligned boxes                 |
-| Policy: Single LP path         | Replace prior abstraction with a single JAX‑first LP entry using JAXopt OSQP (`Q = 0`), tracked in task T5.                                                                                             | `jaxopt`                                   | Unit tests for feasible/infeasible cases; CI green                    |
+| Policy: Single LP path         | Replace prior abstraction with a single JAX‑first LP entry; assess a maintained solver to supersede the deprecated JAXopt OSQP route (tracked in task T5).                                          | pending (JAX‑first solver)      | Unit tests for feasible/infeasible cases; CI green                    |
 | [done] Test fixtures           | Expand `tests/geometry/_polytope_samples.py` with representative polytopes (toric, centrally symmetric, product). Provide expected capacities/volumes when available.                                   | none                                       | Verified values from literature                                       |
 | Benchmark harness              | Add `tests/performance/` cases that exercise each fast implementation with pytest-benchmark markers and profile hooks.                                                                                  | `pytest-benchmark`, `pytest-line-profiler` | Baseline run records stored under `.benchmarks/`                      |
 

--- a/docs/tasks/scheduled/2025-10-05-single-jax-first-lp-solver.md
+++ b/docs/tasks/scheduled/2025-10-05-single-jax-first-lp-solver.md
@@ -38,7 +38,7 @@ We will standardize on JAXopt’s OSQP as the JAX‑first solver. LPs are a spec
 ## 3. Deliverables and exit criteria
 
 - Code:
-  - `viterbo.optimization.linprog_jax` implemented (JAXopt OSQP, `Q = 0`).
+  - `viterbo.optimization.linprog_jax` implemented (JAX-first solver with a maintained OSQP-compatible backend).
   - Deleted files and APIs:
     - `src/viterbo/optimization/solvers.py` (all LP abstractions)
     - `src/viterbo/_wrapped/optimize.py` (SciPy linprog wrapper)
@@ -56,16 +56,14 @@ We will standardize on JAXopt’s OSQP as the JAX‑first solver. LPs are a spec
 
 ## 4. Dependencies and prerequisites
 
-- `jaxopt` is already included in `pyproject.toml` (golden path). Confirm the version meets the
-  minimal requirement; no environment change needed.
+- Select a maintained JAX-first solver dependency (JAXopt replacement) and add it deliberately once chosen; current golden path keeps the slot empty.
 - No change to SciPy usage elsewhere (`_wrapped/spatial.py` remains).
 
 Blocking prerequisites: none; defer execution until currently queued PRs land.
 
 ## 5. Execution plan and checkpoints
 
-1. Implement `linprog_jax` (JAX arrays in/out, shape checks, constraint builder to `A, l, u`, OSQP
-   call with sensible defaults, clear status mapping).
+1. Implement `linprog_jax` (JAX arrays in/out, shape checks, constraint builder to `A, l, u`, call into the chosen maintained solver with sensible defaults, clear status mapping).
 1. Delete LP abstractions and SciPy wrapper; remove all re‑exports.
 1. Update `optimization/__init__.py` and package `__init__.py` to export only `linprog_jax`.
 1. Replace solver tests with `test_linprog_jax.py` and adjust assertions.
@@ -78,7 +76,7 @@ Checkpoint: single PR with focused diff (preferably ≤300 LOC) and CI summary i
 
 - Agent time: Low → Medium (one PR, code + tests + docs).
 - Compute budget: Low (unit tests only).
-- Maintainer involvement: Low (review, environment approval for `jaxopt`).
+- Maintainer involvement: Low (review, dependency approval once the maintained solver is proposed).
 
 ## 7. Testing, benchmarks, and verification
 
@@ -94,7 +92,7 @@ Checkpoint: single PR with focused diff (preferably ≤300 LOC) and CI summary i
   - Mitigation: translate non‑optimal OSQP statuses to `RuntimeError` with clear messages; add unit
     tests.
 - Escalate (Needs-Unblock) if:
-  - Adding `jaxopt` clashes with the devcontainer or CI setup.
+  - The selected maintained solver clashes with the devcontainer or CI setup.
   - Material performance regression (>10%) blocks progress on downstream tasks.
 
 ## 9. Follow-on work

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "highspy>=1.11.0",
     "hypothesis>=6.140.3",
     "jax>=0.7.2",
-    "jaxopt>=0.8.5",
+    "optax>=0.2.4",
     "jaxtyping>=0.3.3",
     "numpy>=2.3.3",
     "orbax-checkpoint>=0.11.25",
@@ -22,6 +22,10 @@ dependencies = [
     "scipy>=1.16.2",
     "tensorboardx>=2.6.4",
     "wandb>=0.22.1",
+    # Planned ML stack once surrogate models ship:
+    # "flax>=0.10.0",  # keep version aligned with optax/jax before enabling.
+    # "diffrax>=0.6.0",  # enable only when ODE-based experiments are scheduled.
+    # "equinox>=0.11.4",  # re-evaluate module system needs with maintainer buy-in.
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
@@ -186,6 +186,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce", size = 100086, upload-time = "2025-08-09T07:56:52.722Z" },
     { url = "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c", size = 107400, upload-time = "2025-08-09T07:56:55.172Z" },
     { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
+]
+
+[[package]]
+name = "chex"
+version = "0.1.91"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "numpy" },
+    { name = "toolz" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/7d/812f01e7b2ddf28a0caa8dde56bd951a2c8f691c9bbfce38d469458d1502/chex-0.1.91.tar.gz", hash = "sha256:65367a521415ada905b8c0222b0a41a68337fcadf79a1fb6fc992dbd95dd9f76", size = 90302, upload-time = "2025-09-01T21:49:32.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/0c/96102c01dd02ae740d4afc3644d5c7d7fc51d3feefd67300a2aa1ddbf7cb/chex-0.1.91-py3-none-any.whl", hash = "sha256:6fc4cbfc22301c08d4a7ef706045668410100962eba8ba6af03fa07f4e5dcf9b", size = 100965, upload-time = "2025-09-01T21:49:31.141Z" },
 ]
 
 [[package]]
@@ -499,21 +516,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/01/e1c44924d3a2a84a6dbc97d9fa515712decc92199a16a519c44e98dcfe33/jaxlib-0.7.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:84e158bbc79eab93b1493cdd031f93e1483b7a26a98edfdd2868f3d0752b0228", size = 53648014, upload-time = "2025-09-16T16:50:07.348Z" },
     { url = "https://files.pythonhosted.org/packages/ee/8e/b16f6f1957aba6736f1c90c0161060deb1c1f4c91ea68cbced3ba7b6e163/jaxlib-0.7.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:4716dc886bda1372a2c78dc6d3c23e50049044d7c552d22a95a14aac6e040731", size = 71659925, upload-time = "2025-09-16T16:50:11.135Z" },
     { url = "https://files.pythonhosted.org/packages/0c/e2/47c52aa806e98f00754b1c303f85d0594d623a7ff5c8592923f7bae45fce/jaxlib-0.7.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:3ecc0b2e76c089cef350f7916275431b299a17615e32ced1ece18cdd47df6bd2", size = 78264963, upload-time = "2025-09-16T16:50:14.613Z" },
-]
-
-[[package]]
-name = "jaxopt"
-version = "0.8.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jax" },
-    { name = "jaxlib" },
-    { name = "numpy" },
-    { name = "scipy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/da/ff7d7fbd13b8ed5e8458e80308d075fc649062b9f8676d3fc56f2dc99a82/jaxopt-0.8.5.tar.gz", hash = "sha256:2790bd68ef132b216c083a8bc7a2704eceb35a92c0fc0a1e652e79dfb1e9e9ab", size = 121709, upload-time = "2025-04-14T17:59:01.618Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/d8/55e0901103c93d57bab3b932294c216f0cbd49054187ce29f8f13808d530/jaxopt-0.8.5-py3-none-any.whl", hash = "sha256:ff221d1a86908ec759eb1e219ee1d12bf208a70707e961bf7401076fe7cf4d5e", size = 172434, upload-time = "2025-04-14T17:59:00.342Z" },
 ]
 
 [[package]]
@@ -906,6 +908,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
+]
+
+[[package]]
+name = "optax"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "chex" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/3b/90c11f740a3538200b61cd2b7d9346959cb9e31e0bdea3d2f886b7262203/optax-0.2.6.tar.gz", hash = "sha256:ba8d1e12678eba2657484d6feeca4fb281b8066bdfd5efbfc0f41b87663109c0", size = 269660, upload-time = "2025-09-15T22:41:24.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/ec/19c6cc6064c7fc8f0cd6d5b37c4747849e66040c6ca98f86565efc2c227c/optax-0.2.6-py3-none-any.whl", hash = "sha256:f875251a5ab20f179d4be57478354e8e21963373b10f9c3b762b94dcb8c36d91", size = 367782, upload-time = "2025-09-15T22:41:22.825Z" },
 ]
 
 [[package]]
@@ -1618,6 +1636,15 @@ wheels = [
 ]
 
 [[package]]
+name = "toolz"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/0b/d80dfa675bf592f636d1ea0b835eab4ec8df6e9415d8cfd766df54456123/toolz-1.0.0.tar.gz", hash = "sha256:2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02", size = 66790, upload-time = "2024-10-04T16:17:04.001Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl", hash = "sha256:292c8f1c4e7516bf9086f8850935c799a874039c8bcf959d47b600e4c44a6236", size = 56383, upload-time = "2024-10-04T16:17:01.533Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1655,9 +1682,9 @@ dependencies = [
     { name = "highspy" },
     { name = "hypothesis" },
     { name = "jax" },
-    { name = "jaxopt" },
     { name = "jaxtyping" },
     { name = "numpy" },
+    { name = "optax" },
     { name = "orbax-checkpoint" },
     { name = "pyarrow" },
     { name = "scipy" },
@@ -1692,13 +1719,13 @@ requires-dist = [
     { name = "highspy", specifier = ">=1.11.0" },
     { name = "hypothesis", specifier = ">=6.140.3" },
     { name = "jax", specifier = ">=0.7.2" },
-    { name = "jaxopt", specifier = ">=0.8.5" },
     { name = "jaxtyping", specifier = ">=0.3.3" },
     { name = "line-profiler", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.0" },
     { name = "mkdocs-htmlproofer-plugin", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.40" },
     { name = "numpy", specifier = ">=2.3.3" },
+    { name = "optax", specifier = ">=0.2.4" },
     { name = "orbax-checkpoint", specifier = ">=0.11.25" },
     { name = "py-spy", marker = "extra == 'dev'", specifier = ">=0.4.1" },
     { name = "pyarrow", specifier = ">=21.0.0" },


### PR DESCRIPTION
## Summary
- replace the deprecated `jaxopt` dependency with `optax` and document the planned ML stack slots
- update the algorithm implementation plan and single-LP task to reflect the new solver decision point
- refresh the lockfile to capture the dependency changes

## Testing
- `uv run python -c "import optax; print(optax.__version__)"`


------
https://chatgpt.com/codex/tasks/task_e_68e3fbbb382c832b92dc5e2fcb0d4524