### PR TITLE
feat: enforce test metadata markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,11 @@ def ehz_capacity(
 ## 6) Testing (facts)
 
 - Structure: organize by feature/module; explicit fixtures; no hidden I/O; clean up temp files.
+- Metadata: every `tests/**/test_*.py` function must declare exactly one goal marker
+  (`@pytest.mark.goal_math`, `@pytest.mark.goal_code`, or `@pytest.mark.goal_performance`) and
+  start with a concise docstring that states the invariant or behaviour under test. Docstrings in
+  `tests/` may use plain prose (no Google-style sections required) but must mention what the test
+  covers and, for math/code markers, which algorithmic surface or property is exercised.
 - Tolerances: choose context‑appropriate tolerances; document rationale. Typical float64 ranges are
   `rtol` ~ 1e‑9–1e‑12 and `atol` near 0.0 for well‑conditioned problems, but adjust as needed.
 - Assertions: use clear options such as `pytest.approx`, `numpy.testing.assert_allclose`,

--- a/Justfile
+++ b/Justfile
@@ -59,6 +59,7 @@ format:
 lint:
     @echo "Running Ruff lint and Prettier check (CI parity)."
     $UV run ruff check .
+    $UV run python scripts/check_test_metadata.py
     {{PRETTIER}} --log-level warn --check {{PRETTIER_PATTERNS}}
 
 # Minimal Ruff diagnostics (E/F/B006/B008).

--- a/docs/test-math-summary.md
+++ b/docs/test-math-summary.md
@@ -1,0 +1,159 @@
+# Test Suite Mathematical Summary
+
+This document captures every test under `tests/` and classifies it as either **Math-level correctness** (establishes or
+regresses mathematical statements about the algorithms), **Code-level correctness** (guards implementation details or
+API/validation contracts without probing new mathematical facts), or **Performance**.
+
+## Geometry — Volume (`tests/viterbo/geometry/volume/test_volume.py`)
+- **test_hypercube_volume_matches_closed_form** — Confirms that both volume estimators agree with the analytic
+  \((2r)^4\) volume of a 4-D cube of radius 1.5. Classification: Math-level correctness.
+- **test_random_polytope_volumes_agree** — Uses a random 4-D polytope to check the reference and fast estimators match,
+  validating numerical stability. Classification: Math-level correctness.
+- **test_simplex_volume_positive** — Ensures the computed volume of a weighted simplex is strictly positive, catching
+  orientation sign errors. Classification: Math-level correctness.
+- **test_hypercube_samples_match_expected_volume** — Verifies that helper-generated sample matrices yield the closed-form
+  3-D cube volume for both estimators. Classification: Math-level correctness.
+
+## Geometry — Polytopes (Transforms) (`tests/viterbo/geometry/polytopes/test_transforms.py`)
+- **test_translate_polytope_updates_offsets** — Checks that translating a polytope updates the offset vector via
+  \(c \mapsto c + Bx\). Classification: Math-level correctness.
+- **test_cartesian_product_dimensions_add** — Verifies that the Cartesian product polytope has additive dimension and
+  facet counts. Classification: Math-level correctness.
+- **test_mirror_polytope_flips_coordinate** — Confirms mirroring negates the specified coordinate in the halfspace
+  matrix. Classification: Math-level correctness.
+- **test_rotate_polytope_consistency_in_plane** — Ensures rotations conjugate the halfspace matrix by the planar rotation
+  matrix, preserving constraints. Classification: Math-level correctness.
+- **test_random_affine_map_is_deterministic_per_seed** — Validates PRNG determinism and conditioning of the sampled
+  affine maps; focuses on reproducibility. Classification: Code-level correctness.
+- **test_random_polytope_facets_are_active** — Confirms randomly generated polytopes keep all facets active (each touches
+  a vertex), preventing degenerate sampling. Classification: Math-level correctness.
+
+## Geometry — Polytopes (Combinatorics) (`tests/viterbo/geometry/polytopes/test_combinatorics.py`)
+- **test_polytope_combinatorics_square_facets** — Checks combinatorial metadata for a square: four vertices with facet
+  degree two. Classification: Math-level correctness.
+- **test_polytope_combinatorics_properties** — Ensures a cube’s combinatorics report the correct adjacency degrees.
+  Classification: Math-level correctness.
+- **test_vertex_enumeration_matches_reference_shape** — Confirms vertex enumeration from halfspaces returns the expected
+  cube vertices. Classification: Math-level correctness.
+- **test_polytope_combinatorics_cached_instances_are_reused** — Ensures caching reuses instances to avoid recomputation.
+  Classification: Code-level correctness.
+- **test_halfspace_vertex_roundtrip** — Validates that converting between vertices and halfspaces is round-trip
+  consistent. Classification: Math-level correctness.
+- **test_polytope_fingerprint_invariant_to_metadata** — Ensures fingerprints ignore metadata changes, focusing on object
+  identity semantics. Classification: Code-level correctness.
+
+## Geometry — Haim–Kislev Action (`tests/viterbo/geometry/polytopes/test_haim_kislev_action.py`)
+- **test_haim_kislev_action_valid_order_matches_reference_capacity** — Checks the Haim–Kislev action matches the known
+  EHZ capacity for the truncated simplex when using a valid subset ordering. Classification: Math-level correctness.
+- **test_haim_kislev_action_invalid_order_raises_value_error** — Ensures invalid permutations trigger input validation.
+  Classification: Code-level correctness.
+
+## Geometry — Halfspaces (`tests/viterbo/geometry/halfspaces/test_halfspaces.py`)
+- **test_reference_enumeration_matches_expected_square** — Confirms the reference vertex enumerator produces the square’s
+  four vertices. Classification: Math-level correctness.
+- **test_fast_enumerator_matches_reference** — Verifies the fast vertex enumerator agrees with the reference results.
+  Classification: Math-level correctness.
+- **test_remove_redundant_facets_discards_duplicates** — Ensures both redundant-facet removers shrink duplicated rows to
+  the canonical four facets. Classification: Math-level correctness.
+
+## Symplectic Core (`tests/viterbo/symplectic/test_core.py`)
+- **test_standard_symplectic_matrix_structure** — Validates the explicit \(J\) matrix form. Classification:
+  Math-level correctness.
+- **test_standard_symplectic_matrix_requires_even_dimension** — Ensures odd dimensions raise errors; this protects the
+  mathematical precondition. Classification: Code-level correctness.
+- **test_symplectic_product_default_matrix** — Checks canonical basis vectors yield expected symplectic pairings.
+  Classification: Math-level correctness.
+- **test_symplectic_product_custom_matrix** — Confirms custom antisymmetric matrices scale the product appropriately.
+  Classification: Math-level correctness.
+- **test_support_function_simplex** — Ensures the simplex support function attains the expected directional value.
+  Classification: Math-level correctness.
+- **test_minkowski_sum_pairwise_vertices** — Verifies Minkowski addition enumerates all pairwise vertex sums.
+  Classification: Math-level correctness.
+- **test_support_function_validates_inputs** — Confirms invalid shapes trigger validation errors. Classification:
+  Code-level correctness.
+- **test_minkowski_sum_validates_inputs** — Ensures shape and dimensionality validation for Minkowski sums.
+  Classification: Code-level correctness.
+- **test_normalize_vector_unit_length** — Checks normalization yields unit norm, catching scaling bugs. Classification:
+  Math-level correctness.
+- **test_normalize_vector_zero_vector_raises** — Ensures zero vectors are rejected. Classification: Code-level correctness.
+- **test_normalize_vector_accepts_list_input** — Confirms list inputs are accepted to smooth API ergonomics.
+  Classification: Code-level correctness.
+- **test_zero_tolerance_reasonable** — Ensures the global tolerance constant stays within a numerically safe range.
+  Classification: Code-level correctness.
+
+## Symplectic Capacity — Reference Implementation (`tests/viterbo/symplectic/capacity/facet_normals/test_reference.py`)
+- **test_capacity_matches_baseline** — Cross-checks reference capacities against catalogued baselines for multiple
+  polytopes. Classification: Math-level correctness.
+- **test_capacity_scales_quadratically_under_dilation** — Verifies \(c_{EHZ}\) scales with the square of dilation.
+  Classification: Math-level correctness.
+- **test_capacity_is_translation_invariant** — Confirms translational invariance of the capacity. Classification:
+  Math-level correctness.
+- **test_truncated_simplex_matches_known_subset_action** — Ensures the truncated simplex’s capacity matches its known
+  optimal action. Classification: Math-level correctness.
+- **test_two_dimensional_simplex_matches_fast_capacity** — Cross-validates the reference and fast implementations on a
+  2-D simplex, ensuring finiteness. Classification: Math-level correctness.
+
+## Symplectic Capacity — Optimized Implementation (`tests/viterbo/symplectic/capacity/facet_normals/test_fast.py`)
+- **test_dynamic_program_matches_bruteforce** — Compares the dynamic program’s antisymmetric order value against a brute
+  force enumeration. Classification: Math-level correctness.
+- **test_fast_implementation_matches_reference** — Parameterized regression ensuring the optimized kernel matches the
+  reference (including shared failure cases). Classification: Math-level correctness.
+
+## Symplectic Capacity — Algorithmic Invariants (`tests/viterbo/symplectic/capacity/facet_normals/test_algorithms.py`)
+- **test_fast_matches_reference** — Cross-check between reference and fast implementations on curated polytopes.
+  Classification: Math-level correctness.
+- **test_symplectic_invariance_square** — Verifies symplectic coordinate changes leave the capacity invariant.
+  Classification: Math-level correctness.
+- **test_rejects_odd_dimension** — Ensures both implementations reject polytopes in odd dimensions. Classification:
+  Code-level correctness.
+- **test_prepare_subset_respects_tol** — Asserts the subset pre-processing honours caller-provided tolerances, focusing
+  on numerical safeguards. Classification: Code-level correctness.
+
+## Symplectic Systolic Ratio (`tests/viterbo/symplectic/systolic/test_systolic.py`)
+- **test_systolic_ratio_translation_invariant** — Confirms translation invariance of the systolic ratio for a simplex.
+  Classification: Math-level correctness.
+- **test_systolic_ratio_scale_invariant** — Checks scaling invariance by dilating the halfspace offsets. Classification:
+  Math-level correctness.
+- **test_simplex_ratio_positive** — Ensures the ratio is strictly positive on the simplex. Classification:
+  Math-level correctness.
+- **test_raw_halfspace_input_validates_shapes** — Validates shape checking for halfspace inputs. Classification:
+  Code-level correctness.
+
+## Optimization — Solvers (`tests/viterbo/optimization/test_solvers.py`)
+- **test_linear_program_validation_rejects_mismatched_rhs** — Ensures constructor validation for linear programs.
+  Classification: Code-level correctness.
+- **test_scipy_backend_solves_simple_problem** — Solves a canonical LP and checks optimal status and solution; validates
+  the API-to-backend wiring. Classification: Code-level correctness.
+- **test_solve_linear_program_uses_default_backend** — Ensures the convenience wrapper delegates to the default backend.
+  Classification: Code-level correctness.
+- **test_mixed_integer_solver_respects_integrality_constraints** — Checks integer-enforced variables snap to integers in
+  an MILP. Classification: Code-level correctness.
+- **test_mixed_integer_solver_supports_maximisation** — Verifies maximisation mode and bound handling in the MILP
+  wrapper. Classification: Code-level correctness.
+- **test_normalize_bounds_expands_scalars** — Ensures scalar bounds broadcast correctly when normalizing constraints.
+  Classification: Code-level correctness.
+- **test_normalize_bounds_validates_sequence** — Confirms invalid-length bounds or inverted intervals raise ValueError.
+  Classification: Code-level correctness.
+- **test_normalize_bounds_rejects_nan_entries** — Ensures NaNs are rejected during bounds normalization. Classification:
+  Code-level correctness.
+
+## Optimization — Search (`tests/viterbo/optimization/test_search.py`)
+- **test_enumerate_search_space_deterministic** — Checks deterministic enumeration when PRNG seed and knobs are fixed.
+  Classification: Code-level correctness.
+- **test_search_space_contains_catalog** — Ensures the search space contains all catalogued base polytopes, protecting
+  coverage. Classification: Math-level correctness.
+- **test_iter_search_space_respects_max_candidates** — Validates iterator truncation behaviour. Classification:
+  Code-level correctness.
+- **test_iter_search_space_rejects_unknown_kwargs** — Ensures unexpected keyword arguments raise errors. Classification:
+  Code-level correctness.
+- **test_iter_search_space_honours_dimension_cap** — Checks enumerator honours the maximum dimension cap. Classification:
+  Code-level correctness.
+
+## Performance Benchmarks — Volume (`tests/performance/viterbo/geometry/volume/test_volume_benchmarks.py`)
+- **test_volume_fast_matches_reference** — Benchmarks the fast volume estimator against the reference while asserting
+  numerical agreement. Classification: Performance (with embedded math check).
+
+## Performance Benchmarks — EHZ Capacity (`tests/performance/viterbo/symplectic/capacity/facet_normals/test_ehz_capacity_benchmarks.py`)
+- **test_fast_ehz_capacity_matches_reference_and_tracks_speed** — Benchmarks the optimized EHZ capacity kernel on the
+  catalogued polytopes, ensuring timing regressions are observable while confirming results match the reference (or
+  share failure messages). Classification: Performance (with embedded math check).

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,9 @@ markers =
     gpu: requires GPU acceleration and is skipped in FAST mode.
     jit: requires JAX JIT and is skipped in FAST mode.
     integration: touches external systems and is skipped in FAST mode.
+    goal_math: validates mathematical properties or invariants.
+    goal_code: validates implementation-level behaviour and error handling.
+    goal_performance: measures runtime characteristics or throughput.
 filterwarnings =
     error::DeprecationWarning
     ignore:Passing arguments 'a', 'a_min' or 'a_max' to jax.numpy.clip is deprecated.:DeprecationWarning

--- a/scripts/check_test_metadata.py
+++ b/scripts/check_test_metadata.py
@@ -1,0 +1,155 @@
+"""Validate that each pytest test declares goal markers and docstrings."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+GOAL_MARKERS = {"goal_math", "goal_code", "goal_performance"}
+
+
+@dataclass
+class TestCase:
+    """Representation of a collected test function."""
+
+    path: Path
+    name: str
+    lineno: int
+    markers: set[str]
+    docstring: str | None
+
+
+def _marker_from_decorator(decorator: ast.AST) -> str | None:
+    """Extract the pytest marker name if the decorator is a goal marker."""
+    target = decorator
+    if isinstance(target, ast.Call):
+        target = target.func
+
+    if isinstance(target, ast.Attribute):
+        if isinstance(target.value, ast.Attribute):
+            if (
+                isinstance(target.value.value, ast.Name)
+                and target.value.value.id == "pytest"
+                and target.value.attr == "mark"
+            ):
+                if target.attr in GOAL_MARKERS:
+                    return target.attr
+    return None
+
+
+def _markers_from_decorators(decorators: Sequence[ast.AST]) -> set[str]:
+    markers: set[str] = set()
+    for decorator in decorators:
+        marker = _marker_from_decorator(decorator)
+        if marker is not None:
+            markers.add(marker)
+    return markers
+
+
+def _collect_tests(
+    node: ast.AST,
+    *,
+    path: Path,
+    parent_markers: Iterable[str] | None = None,
+) -> Iterable[TestCase]:
+    inherited = set(parent_markers or ())
+
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if node.name.startswith("test_"):
+            markers = inherited | _markers_from_decorators(node.decorator_list)
+            docstring = ast.get_docstring(node, clean=False)
+            yield TestCase(
+                path=path,
+                name=node.name,
+                lineno=node.lineno,
+                markers=markers,
+                docstring=docstring,
+            )
+        return
+
+    if isinstance(node, ast.ClassDef):
+        markers = inherited | _markers_from_decorators(node.decorator_list)
+        for child in node.body:
+            yield from _collect_tests(child, path=path, parent_markers=markers)
+        return
+
+    for child in getattr(node, "body", []):
+        yield from _collect_tests(child, path=path, parent_markers=inherited)
+
+
+def _iter_test_files(paths: Sequence[str]) -> Iterable[Path]:
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            yield from sorted(path.rglob("test_*.py"))
+        elif path.suffix == ".py":
+            yield path
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the metadata check CLI."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Ensure each pytest test has a goal marker (goal_math, goal_code, or "
+            "goal_performance) and a descriptive docstring."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["tests"],
+        help="File or directory roots to scan (default: tests).",
+    )
+    args = parser.parse_args(argv)
+
+    issues: list[str] = []
+    total_tests = 0
+    files_scanned = 0
+
+    for path in _iter_test_files(args.paths):
+        files_scanned += 1
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        for testcase in _collect_tests(tree, path=path):
+            total_tests += 1
+            goal_markers = testcase.markers & GOAL_MARKERS
+            if not goal_markers:
+                issues.append(
+                    f"{testcase.path}:{testcase.lineno}: "
+                    "missing goal marker (use one of goal_math, goal_code, goal_performance)."
+                )
+            elif len(goal_markers) > 1:
+                joined = ", ".join(sorted(goal_markers))
+                issues.append(
+                    f"{testcase.path}:{testcase.lineno}: "
+                    f"multiple goal markers detected ({joined}); choose exactly one."
+                )
+
+            if testcase.docstring is None or not testcase.docstring.strip():
+                issues.append(
+                    f"{testcase.path}:{testcase.lineno}: "
+                    "missing or empty docstring describing the test's intent."
+                )
+
+    if issues:
+        sys.stderr.write("Found test metadata issues:\n")
+        for issue in issues:
+            sys.stderr.write(f"{issue}\n")
+        sys.stderr.write(
+            "Hint: annotate each test with a goal marker (e.g., @pytest.mark.goal_math) "
+            "and add a high-level docstring describing the invariant or behaviour.\n"
+        )
+        return 1
+
+    sys.stdout.write(
+        f"Validated {total_tests} tests across {files_scanned} files; all have goal markers and docstrings.\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    sys.exit(main())

--- a/tests/performance/viterbo/geometry/volume/test_volume_benchmarks.py
+++ b/tests/performance/viterbo/geometry/volume/test_volume_benchmarks.py
@@ -14,10 +14,12 @@ from viterbo.geometry.volume import polytope_volume_fast, polytope_volume_refere
 pytestmark = [pytest.mark.smoke, pytest.mark.deep]
 
 
+@pytest.mark.goal_performance
 @pytest.mark.benchmark
 def test_volume_fast_matches_reference(
     benchmark: pytest_benchmark.plugin.BenchmarkFixture,
 ) -> None:
+    """Benchmark the fast volume estimator while asserting parity with the reference."""
     key = jax.random.PRNGKey(314)
     polytope = random_polytope(4, key=key, name="volume-bench")
     B, c = polytope.halfspace_data()

--- a/tests/performance/viterbo/symplectic/capacity/facet_normals/test_ehz_capacity_benchmarks.py
+++ b/tests/performance/viterbo/symplectic/capacity/facet_normals/test_ehz_capacity_benchmarks.py
@@ -13,10 +13,10 @@ import numpy as np
 import pytest
 import pytest_benchmark.plugin  # type: ignore[reportMissingTypeStubs]  # Third-party plugin has no stubs; TODO: add types or vendor stubs
 
-
 pytestmark = [pytest.mark.smoke, pytest.mark.deep]
 
 from tests._utils.polytope_samples import load_polytope_instances
+
 from viterbo.symplectic.capacity import compute_ehz_capacity_reference
 from viterbo.symplectic.capacity.facet_normals.fast import compute_ehz_capacity_fast
 
@@ -30,6 +30,7 @@ _POLYTOPE_INSTANCES = _POLYTOPE_DATA[0]
 _POLYTOPE_IDS = _POLYTOPE_DATA[1]
 
 
+@pytest.mark.goal_performance
 @pytest.mark.benchmark(group="ehz_capacity")
 @pytest.mark.parametrize(("B", "c"), _POLYTOPE_INSTANCES, ids=_POLYTOPE_IDS)
 def test_fast_ehz_capacity_matches_reference_and_tracks_speed(

--- a/tests/viterbo/geometry/halfspaces/test_halfspaces.py
+++ b/tests/viterbo/geometry/halfspaces/test_halfspaces.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from jaxtyping import Array, Float
 
 from viterbo.geometry.halfspaces import (
@@ -29,8 +30,9 @@ def _run_enumerator(
     vertices = enumerator(matrix, offsets)
     return np.asarray(vertices, dtype=float)
 
-
+@pytest.mark.goal_math
 def test_reference_enumeration_matches_expected_square() -> None:
+    """Reference enumeration returns the vertices of the canonical unit square."""
     vertices = _run_enumerator(enumerate_vertices_reference)
     expected = np.array(
         [
@@ -44,7 +46,9 @@ def test_reference_enumeration_matches_expected_square() -> None:
     assert np.allclose(_sorted_rows(vertices), _sorted_rows(expected))
 
 
+@pytest.mark.goal_math
 def test_fast_enumerator_matches_reference() -> None:
+    """The fast vertex enumerator matches the reference implementation on the square."""
     ref = _run_enumerator(enumerate_vertices_reference)
     fast = _run_enumerator(enumerate_vertices_fast)
     expected = np.array(
@@ -59,7 +63,9 @@ def test_fast_enumerator_matches_reference() -> None:
     assert np.allclose(_sorted_rows(fast), _sorted_rows(expected))
 
 
+@pytest.mark.goal_code
 def test_remove_redundant_facets_discards_duplicates() -> None:
+    """Redundant facets are removed consistently by reference and fast implementations."""
     matrix, offsets = unit_square_halfspaces()
     matrix = jnp.vstack((matrix, matrix[0:1]))
     offsets = jnp.concatenate((offsets, offsets[0:1]))

--- a/tests/viterbo/geometry/polytopes/test_combinatorics.py
+++ b/tests/viterbo/geometry/polytopes/test_combinatorics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from viterbo.geometry.polytopes import (
     PolytopeCombinatorics,
@@ -23,8 +24,9 @@ def _sort_halfspaces(
     key = np.lexsort(np.column_stack((B_np, c_np)).T)
     return B_np[key], c_np[key]
 
-
+@pytest.mark.goal_math
 def test_polytope_combinatorics_square_facets() -> None:
+    """Facet adjacency for a square has degree two across all faces."""
     square = hypercube(2)
     combinatorics = polytope_combinatorics(square, use_cache=False)
 
@@ -35,8 +37,9 @@ def test_polytope_combinatorics_square_facets() -> None:
     degree = combinatorics.facet_adjacency.sum(axis=1)
     assert np.all(degree == 2)
 
-
+@pytest.mark.goal_math
 def test_polytope_combinatorics_properties() -> None:
+    """Cube facet adjacency matches the expected combinatorial degree structure."""
     cube = hypercube(3)
     baseline = polytope_combinatorics(cube, use_cache=False)
 
@@ -52,8 +55,9 @@ def _sorted_vertices(vertices: object) -> np.ndarray:
     keys = np.lexsort(array.T[::-1])
     return array[keys]
 
-
+@pytest.mark.goal_math
 def test_vertex_enumeration_matches_reference_shape() -> None:
+    """Vertex enumeration from halfspaces matches the expected sorted coordinates."""
     cube = hypercube(3)
     B, c = cube.halfspace_data()
     reference_vertices = vertices_from_halfspaces(B, c)
@@ -61,14 +65,18 @@ def test_vertex_enumeration_matches_reference_shape() -> None:
     assert np.allclose(_sorted_vertices(reference_vertices), expected)
 
 
+@pytest.mark.goal_code
 def test_polytope_combinatorics_cached_instances_are_reused() -> None:
+    """Repeated combinatorics calls with caching return the same object instance."""
     cube = hypercube(3)
     first = polytope_combinatorics(cube, use_cache=True)
     second = polytope_combinatorics(cube, use_cache=True)
     assert first is second
 
 
+@pytest.mark.goal_math
 def test_halfspace_vertex_roundtrip() -> None:
+    """Round-tripping between halfspaces and vertices preserves geometry."""
     cube = hypercube(3)
     B, c = cube.halfspace_data()
     vertices = vertices_from_halfspaces(B, c)
@@ -78,8 +86,9 @@ def test_halfspace_vertex_roundtrip() -> None:
     assert np.allclose(actual_B, expected_B)
     assert np.allclose(actual_c, expected_c)
 
-
+@pytest.mark.goal_code
 def test_polytope_fingerprint_invariant_to_metadata() -> None:
+    """Fingerprints depend on geometry only and ignore metadata like names."""
     cube = hypercube(3)
     renamed = cube.with_metadata(name="renamed-cube")
     assert polytope_fingerprint(cube) == polytope_fingerprint(renamed)

--- a/tests/viterbo/geometry/polytopes/test_haim_kislev_action.py
+++ b/tests/viterbo/geometry/polytopes/test_haim_kislev_action.py
@@ -9,7 +9,9 @@ import pytest
 from viterbo.geometry.polytopes import haim_kislev_action, truncated_simplex_four_dim
 
 
+@pytest.mark.goal_math
 def test_haim_kislev_action_valid_order_matches_reference_capacity() -> None:
+    """The action equals the known reference capacity for the canonical simplex order."""
     polytope = truncated_simplex_four_dim()
     subset = (0, 1, 2, 3, 4)
     order = (2, 0, 4, 3, 1)
@@ -18,8 +20,9 @@ def test_haim_kislev_action_valid_order_matches_reference_capacity() -> None:
     assert reference_capacity is not None
     assert math.isclose(action, reference_capacity, rel_tol=1e-9, abs_tol=0.0)
 
-
+@pytest.mark.goal_code
 def test_haim_kislev_action_invalid_order_raises_value_error() -> None:
+    """Invalid permutations trigger validation errors before computing the action."""
     polytope = truncated_simplex_four_dim()
     subset = (0, 1, 2, 3, 4)
     invalid_order = (2, 0, 4, 4, 1)

--- a/tests/viterbo/geometry/polytopes/test_transforms.py
+++ b/tests/viterbo/geometry/polytopes/test_transforms.py
@@ -23,7 +23,9 @@ from viterbo.geometry.polytopes import (
 )
 
 
+@pytest.mark.goal_code
 def test_translate_polytope_updates_offsets() -> None:
+    """Translating a polytope shifts its half-space offsets by B @ translation."""
     polytope = hypercube(2)
     translation = jnp.array([0.5, -0.25])
     translated = translate_polytope(polytope, translation)
@@ -32,8 +34,9 @@ def test_translate_polytope_updates_offsets() -> None:
         np.asarray(translated.c), np.asarray(expected_c), rtol=1e-9, atol=0.0
     )
 
-
+@pytest.mark.goal_math
 def test_cartesian_product_dimensions_add() -> None:
+    """Cartesian products add both dimension and facet counts."""
     cube = hypercube(2)
     cross = cross_polytope(2)
     product = cartesian_product(cube, cross)
@@ -41,15 +44,18 @@ def test_cartesian_product_dimensions_add() -> None:
     assert product.facets == cube.facets + cross.facets
 
 
+@pytest.mark.goal_code
 def test_mirror_polytope_flips_coordinate() -> None:
+    """Mirroring across an axis negates the corresponding facet coefficients."""
     polytope = simplex_with_uniform_weights(3)
     mirrored = mirror_polytope(polytope, axes=(True, False, False))
     expected_B = polytope.B.copy()
     expected_B = expected_B.at[:, 0].multiply(-1)
     np.testing.assert_allclose(np.asarray(mirrored.B), np.asarray(expected_B), rtol=1e-9, atol=0.0)
 
-
+@pytest.mark.goal_math
 def test_rotate_polytope_consistency_in_plane() -> None:
+    """Rotation updates facet normals according to the inverse rotation matrix."""
     polytope = hypercube(2)
     angle = math.pi / 4
     rotated = rotate_polytope(polytope, plane=(0, 1), angle=angle)
@@ -59,8 +65,9 @@ def test_rotate_polytope_consistency_in_plane() -> None:
     expected_B = polytope.B @ jnp.linalg.inv(rotation_matrix)
     np.testing.assert_allclose(np.asarray(rotated.B), np.asarray(expected_B), rtol=1e-9, atol=0.0)
 
-
+@pytest.mark.goal_code
 def test_random_affine_map_is_deterministic_per_seed() -> None:
+    """Random affine maps are reproducible with a fixed seed and well-conditioned."""
     key = jax.random.PRNGKey(10)
     matrix_a, translation_a = random_affine_map(4, key=key)
     matrix_b, translation_b = random_affine_map(4, key=key)
@@ -77,8 +84,10 @@ def test_random_affine_map_is_deterministic_per_seed() -> None:
     assert np.linalg.cond(np.asarray(matrix_a)) < 1e6
 
 
+@pytest.mark.goal_math
 @pytest.mark.deep
 def test_random_polytope_facets_are_active() -> None:
+    """Every generated facet is tight for at least one enumerated vertex."""
     key = jax.random.PRNGKey(2024)
     polytope = random_polytope(3, key=key, name="random-3d-test")
     vertices = enumerate_vertices(polytope.B, polytope.c)

--- a/tests/viterbo/geometry/volume/test_volume.py
+++ b/tests/viterbo/geometry/volume/test_volume.py
@@ -24,8 +24,9 @@ def _volumes(polytope: Polytope) -> tuple[float, float]:
     B, c = polytope.halfspace_data()
     return polytope_volume_reference(B, c), polytope_volume_fast(B, c)
 
-
+@pytest.mark.goal_math
 def test_hypercube_volume_matches_closed_form() -> None:
+    """Both volume estimators match the analytic volume of a hypercube."""
     cube = hypercube(4, radius=1.5)
     reference, fast = _volumes(cube)
     expected = (2 * 1.5) ** 4
@@ -33,22 +34,28 @@ def test_hypercube_volume_matches_closed_form() -> None:
     assert math.isclose(fast, expected, rel_tol=1e-9)
 
 
+@pytest.mark.goal_math
 @pytest.mark.deep
 def test_random_polytope_volumes_agree() -> None:
+    """Reference and fast volume estimators agree on random 4D polytopes."""
     key = jax.random.PRNGKey(42)
     polytope = random_polytope(4, key=key, name="random-test")
     reference, fast = _volumes(polytope)
     assert math.isclose(reference, fast, rel_tol=1e-9, abs_tol=1e-9)
 
 
+@pytest.mark.goal_math
 def test_simplex_volume_positive() -> None:
+    """Volumes computed for the simplex are positive for both algorithms."""
     simplex = simplex_with_uniform_weights(4)
     reference, fast = _volumes(simplex)
     assert reference > 0
     assert fast > 0
 
 
+@pytest.mark.goal_math
 def test_hypercube_samples_match_expected_volume() -> None:
+    """Generating hypercube volume inputs reproduces the analytic expectation."""
     matrix, offsets, expected = hypercube_volume_inputs(3, radius=2.0)
     reference = polytope_volume_reference(matrix, offsets)
     fast = polytope_volume_fast(matrix, offsets)

--- a/tests/viterbo/optimization/test_search.py
+++ b/tests/viterbo/optimization/test_search.py
@@ -8,7 +8,9 @@ from viterbo.geometry.polytopes import catalog
 from viterbo.optimization.search import enumerate_search_space, iter_search_space
 
 
+@pytest.mark.goal_code
 def test_enumerate_search_space_deterministic() -> None:
+    """Enumerating the search space with identical seeds yields identical sequences."""
     first = enumerate_search_space(
         rng_seed=11,
         max_dimension=4,
@@ -30,7 +32,9 @@ def test_enumerate_search_space_deterministic() -> None:
         assert poly_a.c.shape == poly_b.c.shape
 
 
+@pytest.mark.goal_math
 def test_search_space_contains_catalog() -> None:
+    """The search enumeration includes every canonical polytope from the catalog."""
     search_space = enumerate_search_space(
         rng_seed=5,
         max_dimension=4,
@@ -43,7 +47,9 @@ def test_search_space_contains_catalog() -> None:
     assert catalog_names.issubset(search_names)
 
 
+@pytest.mark.goal_code
 def test_iter_search_space_respects_max_candidates() -> None:
+    """The iterator stops once it yields the requested number of candidates."""
     polytopes = list(
         iter_search_space(
             max_candidates=5,
@@ -55,12 +61,16 @@ def test_iter_search_space_respects_max_candidates() -> None:
     assert len(polytopes) == 5
 
 
+@pytest.mark.goal_code
 def test_iter_search_space_rejects_unknown_kwargs() -> None:
+    """`iter_search_space` raises when callers supply unsupported keyword arguments."""
     with pytest.raises(TypeError, match="Unknown keyword arguments"):
         next(iter_search_space(unknown=1))
 
 
+@pytest.mark.goal_code
 def test_iter_search_space_honours_dimension_cap() -> None:
+    """Generated polytopes do not exceed the requested maximum dimension."""
     polytopes = list(
         iter_search_space(
             max_dimension=3,

--- a/tests/viterbo/optimization/test_solvers.py
+++ b/tests/viterbo/optimization/test_solvers.py
@@ -10,21 +10,25 @@ import pytest
 
 from viterbo.optimization.solvers import (
     LinearProgram,
+    MixedIntegerLinearProgram,
     ScipyLinearProgramBackend,
     _normalize_bounds,
-    MixedIntegerLinearProgram,
-    solve_mixed_integer_linear_program,
     solve_linear_program,
+    solve_mixed_integer_linear_program,
 )
 
 
+@pytest.mark.goal_code
 def test_linear_program_validation_rejects_mismatched_rhs() -> None:
+    """LinearProgram rejects RHS vectors whose length mismatches the constraints."""
     objective = jnp.ones(2)
     with pytest.raises(ValueError):
         LinearProgram(objective=objective, lhs_ineq=jnp.ones((1, 2)), rhs_ineq=jnp.ones(2))
 
 
+@pytest.mark.goal_math
 def test_scipy_backend_solves_simple_problem() -> None:
+    """The SciPy backend recovers the analytic solution of a toy LP."""
     problem = LinearProgram(
         objective=jnp.array([1.0, 0.0]),
         lhs_ineq=jnp.array([[-1.0, 0.0], [0.0, -1.0]]),
@@ -39,7 +43,9 @@ def test_scipy_backend_solves_simple_problem() -> None:
     assert math.isclose(solution.objective_value, 0.0, rel_tol=0.0, abs_tol=1e-8)
 
 
+@pytest.mark.goal_code
 def test_solve_linear_program_uses_default_backend() -> None:
+    """`solve_linear_program` delegates to the default backend for the toy LP."""
     problem = LinearProgram(
         objective=jnp.array([0.0, 1.0]),
         lhs_ineq=jnp.array([[-1.0, 0.0], [0.0, -1.0]]),
@@ -52,7 +58,9 @@ def test_solve_linear_program_uses_default_backend() -> None:
     np.testing.assert_allclose(solution.x, np.array([1.0, 0.0]), rtol=1e-9, atol=1e-8)
 
 
+@pytest.mark.goal_math
 def test_mixed_integer_solver_respects_integrality_constraints() -> None:
+    """The mixed-integer solver honours integrality flags on variables."""
     problem = MixedIntegerLinearProgram(
         objective=jnp.array([1.0, 0.1]),
         lhs_ineq=jnp.array([[1.0, 2.0]]),
@@ -70,7 +78,9 @@ def test_mixed_integer_solver_respects_integrality_constraints() -> None:
     assert math.isclose(solution.objective_value, 1.0, rel_tol=0.0, abs_tol=1e-9)
 
 
+@pytest.mark.goal_math
 def test_mixed_integer_solver_supports_maximisation() -> None:
+    """The solver handles maximisation problems by mirroring the objective."""
     problem = MixedIntegerLinearProgram(
         objective=jnp.array([1.0, 1.0]),
         lhs_ineq=jnp.array([[1.0, 1.0]]),
@@ -87,8 +97,9 @@ def test_mixed_integer_solver_supports_maximisation() -> None:
     assert math.isclose(float(np.sum(solution.x)), 1.5, rel_tol=0.0, abs_tol=1e-9)
     assert math.isclose(solution.objective_value, 1.5, rel_tol=0.0, abs_tol=1e-9)
 
-
+@pytest.mark.goal_code
 def test_normalize_bounds_expands_scalars() -> None:
+    """`_normalize_bounds` broadens scalar bounds into per-variable tuples."""
     class DummyBounds:
         def __init__(self) -> None:
             self.lb = -1.0
@@ -97,15 +108,17 @@ def test_normalize_bounds_expands_scalars() -> None:
     normalized = _normalize_bounds(DummyBounds(), dimension=3)
     assert normalized == ((-1.0, 2.0), (-1.0, None), (-1.0, 0.5))
 
-
+@pytest.mark.goal_code
 def test_normalize_bounds_validates_sequence() -> None:
+    """`_normalize_bounds` enforces length and ordering constraints for sequences."""
     with pytest.raises(ValueError, match="Bounds length must match"):
         _normalize_bounds([(0.0, 1.0)], dimension=2)
 
     with pytest.raises(ValueError, match="Lower bound exceeds upper bound"):
         _normalize_bounds([(0.0, -0.5)], dimension=1)
 
-
+@pytest.mark.goal_code
 def test_normalize_bounds_rejects_nan_entries() -> None:
+    """`_normalize_bounds` refuses NaN inputs to prevent invalid solver requests."""
     with pytest.raises(ValueError, match="Bounds must not contain NaN"):
         _normalize_bounds([(float('nan'), 1.0)], dimension=1)

--- a/tests/viterbo/symplectic/capacity/facet_normals/test_algorithms.py
+++ b/tests/viterbo/symplectic/capacity/facet_normals/test_algorithms.py
@@ -7,8 +7,8 @@ import math
 import numpy as np
 import pytest
 from pytest import MonkeyPatch
-
 from tests._utils.polytope_samples import load_polytope_instances
+
 from viterbo.geometry.polytopes import (
     cross_polytope,
     hypercube,
@@ -92,6 +92,7 @@ def fixture_subset_utils_close_records(
     return records
 
 
+@pytest.mark.goal_math
 @pytest.mark.parametrize(("B", "c"), _CAPACITY_CASES)
 def test_fast_matches_reference(B: np.ndarray, c: np.ndarray) -> None:
     """Reference and fast implementations should agree on sample polytopes."""
@@ -106,6 +107,7 @@ def test_fast_matches_reference(B: np.ndarray, c: np.ndarray) -> None:
         assert math.isclose(reference_value, fast_value, rel_tol=1e-10, abs_tol=1e-12)
 
 
+@pytest.mark.goal_math
 def test_symplectic_invariance_square() -> None:
     """A linear symplectic change of coordinates preserves the capacity."""
     B, c = _BASE_INSTANCES[0]
@@ -132,6 +134,7 @@ def test_symplectic_invariance_square() -> None:
     assert math.isclose(float(base), float(transformed), rel_tol=1e-10, abs_tol=1e-12)  # type: ignore[reportUnknownArgumentType]
 
 
+@pytest.mark.goal_code
 def test_rejects_odd_dimension() -> None:
     """Polytopes in odd ambient dimension should raise a ``ValueError``."""
     B = np.eye(3)
@@ -142,6 +145,7 @@ def test_rejects_odd_dimension() -> None:
         compute_ehz_capacity_fast(B, c)  # type: ignore[reportArgumentType]
 
 
+@pytest.mark.goal_code
 def test_prepare_subset_respects_tol(
     subset_utils_close_records: dict[str, float | None],
 ) -> None:

--- a/tests/viterbo/symplectic/capacity/facet_normals/test_fast.py
+++ b/tests/viterbo/symplectic/capacity/facet_normals/test_fast.py
@@ -8,8 +8,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-
 from tests._utils.polytope_samples import load_polytope_instances
+
 from viterbo.geometry.polytopes import (
     cross_polytope,
     hypercube,
@@ -24,7 +24,9 @@ from viterbo.symplectic.capacity.facet_normals.subset_utils import (
 )
 
 
+@pytest.mark.goal_math
 def test_dynamic_program_matches_bruteforce() -> None:
+    """The DP relaxation recovers the brute-force optimum for antisymmetric weights."""
     key = jax.random.PRNGKey(0)
     weights = jax.random.normal(key, (5, 5), dtype=jnp.float64)
     weights = weights - weights.T
@@ -73,6 +75,7 @@ _FAST_CASES = _SMOKE_FAST_CASES + _DEEP_STATIC_FAST_CASES + tuple(
 
 
 @pytest.mark.parametrize(("B", "c"), _FAST_CASES)
+@pytest.mark.goal_math
 def test_fast_implementation_matches_reference(B: np.ndarray, c: np.ndarray) -> None:
     """The accelerated implementation matches the reference for diverse polytopes."""
 

--- a/tests/viterbo/symplectic/capacity/facet_normals/test_reference.py
+++ b/tests/viterbo/symplectic/capacity/facet_normals/test_reference.py
@@ -6,8 +6,8 @@ import math
 
 import jax.numpy as jnp
 import pytest
-
 from tests._utils.baselines import load_baseline
+
 from viterbo.geometry.polytopes import (
     Polytope,
     catalog,
@@ -27,6 +27,7 @@ _BASELINE_CAPACITIES = {
 }
 _POLYTOPE_LOOKUP = {poly.name: poly for poly in catalog()}
 
+@pytest.mark.goal_math
 @pytest.mark.parametrize(
     "polytope_name",
     sorted(_BASELINE_CAPACITIES.keys()),
@@ -41,6 +42,7 @@ def test_capacity_matches_baseline(polytope_name: str) -> None:
     assert math.isclose(capacity, expected, rel_tol=0.0, abs_tol=1e-9)
 
 
+@pytest.mark.goal_math
 def test_capacity_scales_quadratically_under_dilation() -> None:
     r"""Scaling the polytope dilates the capacity by the square factor."""
 
@@ -54,6 +56,7 @@ def test_capacity_scales_quadratically_under_dilation() -> None:
     assert math.isclose(scaled_capacity, (scale**2) * base_capacity, rel_tol=0.0, abs_tol=1e-8)
 
 
+@pytest.mark.goal_math
 def test_capacity_is_translation_invariant() -> None:
     """Rigid translations of the polytope leave ``c_EHZ`` unchanged."""
 
@@ -69,6 +72,7 @@ def test_capacity_is_translation_invariant() -> None:
     assert math.isclose(translated_capacity, base_capacity, rel_tol=0.0, abs_tol=1e-9)
 
 
+@pytest.mark.goal_math
 def test_truncated_simplex_matches_known_subset_action() -> None:
     """Adding an extra facet leaves the optimal action unchanged."""
 
@@ -80,6 +84,7 @@ def test_truncated_simplex_matches_known_subset_action() -> None:
     assert math.isclose(capacity, polytope.reference_capacity, rel_tol=0.0, abs_tol=1e-9)
 
 
+@pytest.mark.goal_math
 def test_two_dimensional_simplex_matches_fast_capacity() -> None:
     """The 2D simplex yields a finite, consistent capacity across implementations."""
 

--- a/tests/viterbo/symplectic/systolic/test_systolic.py
+++ b/tests/viterbo/symplectic/systolic/test_systolic.py
@@ -12,25 +12,33 @@ from viterbo.geometry.polytopes import simplex_with_uniform_weights, translate_p
 from viterbo.symplectic.systolic import systolic_ratio
 
 
+@pytest.mark.goal_math
 def test_systolic_ratio_translation_invariant() -> None:
+    """Translating a simplex leaves the systolic ratio unchanged."""
     simplex = simplex_with_uniform_weights(4)
     translated = translate_polytope(simplex, jnp.array([0.2, -0.3, 0.4, 0.1]))
     assert math.isclose(systolic_ratio(simplex), systolic_ratio(translated), rel_tol=1e-9)
 
 
+@pytest.mark.goal_math
 def test_systolic_ratio_scale_invariant() -> None:
+    """Scaling a polytope rescales its halfspaces without changing the ratio."""
     simplex = simplex_with_uniform_weights(4)
     B, c = simplex.halfspace_data()
     scaled_ratio = systolic_ratio(B, 1.5 * c)
     assert math.isclose(systolic_ratio(simplex), scaled_ratio, rel_tol=1e-9)
 
 
+@pytest.mark.goal_math
 def test_simplex_ratio_positive() -> None:
+    """The systolic ratio of the canonical simplex is strictly positive."""
     simplex = simplex_with_uniform_weights(4)
     assert systolic_ratio(simplex) > 0.0
 
 
+@pytest.mark.goal_code
 def test_raw_halfspace_input_validates_shapes() -> None:
+    """Shape mismatches in halfspace inputs trigger validation errors."""
     B = np.array([1.0, -1.0])
     c = np.array([1.0, 1.0])
     with pytest.raises(ValueError):

--- a/tests/viterbo/symplectic/test_core.py
+++ b/tests/viterbo/symplectic/test_core.py
@@ -18,7 +18,9 @@ from viterbo.symplectic.core import (
 )
 
 
+@pytest.mark.goal_math
 def test_standard_symplectic_matrix_structure() -> None:
+    """The canonical symplectic form has the expected block off-diagonal structure."""
     matrix = standard_symplectic_matrix(4)
     expected = np.array(
         [
@@ -30,14 +32,17 @@ def test_standard_symplectic_matrix_structure() -> None:
     )
     np.testing.assert_array_equal(np.asarray(matrix), expected)
 
-
+@pytest.mark.goal_code
 @pytest.mark.parametrize("dimension", [1, 3])
 def test_standard_symplectic_matrix_requires_even_dimension(dimension: int) -> None:
+    """Odd-dimensional requests raise errors because the symplectic matrix is 2n×2n."""
     with pytest.raises(ValueError):
         standard_symplectic_matrix(dimension)
 
 
+@pytest.mark.goal_math
 def test_symplectic_product_default_matrix() -> None:
+    """Symplectic products respect the canonical pairing on standard basis vectors."""
     vector_a = jnp.array([1.0, 0.0, 0.0, 0.0])
     vector_b = jnp.array([0.0, 1.0, 0.0, 0.0])
     value = symplectic_product(vector_a, vector_b)
@@ -48,14 +53,17 @@ def test_symplectic_product_default_matrix() -> None:
     value_cd = symplectic_product(vector_c, vector_d)
     assert math.isclose(value_cd, 1.0, rel_tol=1e-12, abs_tol=0.0)
 
-
+@pytest.mark.goal_math
 def test_symplectic_product_custom_matrix() -> None:
+    """Supplying a custom symplectic matrix rescales the pairing accordingly."""
     matrix = jnp.array([[0.0, 2.0], [-2.0, 0.0]])
     value = symplectic_product(jnp.array([1.0, 0.0]), jnp.array([0.0, 1.0]), matrix=matrix)
     assert math.isclose(value, 2.0, rel_tol=1e-12, abs_tol=0.0)
 
 
+@pytest.mark.goal_math
 def test_support_function_simplex() -> None:
+    """Support function of a simplex equals the maximum dot product along a direction."""
     vertices = jnp.array(
         [
             [0.0, 0.0],
@@ -68,7 +76,9 @@ def test_support_function_simplex() -> None:
     assert math.isclose(value, 1.0, rel_tol=1e-12, abs_tol=0.0)
 
 
+@pytest.mark.goal_math
 def test_minkowski_sum_pairwise_vertices() -> None:
+    """Minkowski sums enumerate pairwise vertex additions for convex polytopes."""
     square = jnp.array(
         [
             [0.0, 0.0],
@@ -94,7 +104,9 @@ def test_minkowski_sum_pairwise_vertices() -> None:
     np.testing.assert_array_equal(np.asarray(result), expected)
 
 
+@pytest.mark.goal_code
 def test_support_function_validates_inputs() -> None:
+    """Support function rejects empty vertices, rank mismatches, and invalid directions."""
     with pytest.raises(ValueError):
         support_function(jnp.empty((0, 2)), jnp.array([1.0, 0.0]))
 
@@ -105,7 +117,9 @@ def test_support_function_validates_inputs() -> None:
         support_function(jnp.array([[1.0, 0.0]]), jnp.array([1.0, 0.0, 0.0]))
 
 
+@pytest.mark.goal_code
 def test_minkowski_sum_validates_inputs() -> None:
+    """Minkowski sum enforces non-empty operands with matching dimensions."""
     with pytest.raises(ValueError):
         minkowski_sum(jnp.empty((0, 2)), jnp.array([[1.0, 0.0]]))
 
@@ -116,25 +130,33 @@ def test_minkowski_sum_validates_inputs() -> None:
         minkowski_sum(jnp.array([[1.0, 0.0]]), jnp.array([[1.0, 0.0, 0.0]]))
 
 
+@pytest.mark.goal_math
 def test_normalize_vector_unit_length() -> None:
+    """Normalising a vector scales it to unit length under the Euclidean norm."""
     vector = jnp.array([3.0, 4.0])
     normalized = normalize_vector(vector)
     norm = float(jnp.linalg.norm(jnp.asarray(normalized)))
     assert math.isclose(norm, 1.0, rel_tol=1e-12, abs_tol=0.0)
 
 
+@pytest.mark.goal_code
 def test_normalize_vector_zero_vector_raises() -> None:
+    """Normalisation rejects the zero vector because it has undefined direction."""
     zero = jnp.zeros(3)
     with pytest.raises(ValueError):
         normalize_vector(zero)
 
 
+@pytest.mark.goal_code
 def test_normalize_vector_accepts_list_input() -> None:
+    """Lists are coerced to arrays before normalisation to support ergonomic APIs."""
     values = [3.0, 4.0, 12.0]
     normalized = normalize_vector(values)  # type: ignore[reportArgumentType]
     norm = float(jnp.linalg.norm(jnp.asarray(normalized)))
     assert math.isclose(norm, 1.0, rel_tol=1e-12, abs_tol=0.0)
 
 
+@pytest.mark.goal_code
 def test_zero_tolerance_reasonable() -> None:
+    """The default numerical tolerance is positive yet comfortably small."""
     assert 0.0 < ZERO_TOLERANCE < 1e-6


### PR DESCRIPTION
## Summary
- add a central document describing each test module and whether it enforces math-level, code-level, or performance guarantees
- add pytest goal markers and descriptive docstrings across tests and benchmarks to make intent machine-readable
- introduce a metadata validation script and hook it into `just lint` so the convention is enforced automatically

## Testing
- python scripts/check_test_metadata.py
- just lint *(fails: existing Ruff violations in scripts/check_waivers.py)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fb2280c8832b90884591a5ad30aa