### PR TITLE
feat: add test metadata reporting utility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,8 @@ def ehz_capacity(
   start with a concise docstring that states the invariant or behaviour under test. Docstrings in
   `tests/` may use plain prose (no Google-style sections required) but must mention what the test
   covers and, for math/code markers, which algorithmic surface or property is exercised.
+- To inspect metadata quickly, run `just test-metadata ARGS="--marker goal_math"` (omit `ARGS` to
+  list everything). The script prints a deterministic summary (`LINES:<n>` + `path::test` rows).
 - Tolerances: choose context‑appropriate tolerances; document rationale. Typical float64 ranges are
   `rtol` ~ 1e‑9–1e‑12 and `atol` near 0.0 for well‑conditioned problems, but adjust as needed.
 - Assertions: use clear options such as `pytest.approx`, `numpy.testing.assert_allclose`,

--- a/Justfile
+++ b/Justfile
@@ -62,6 +62,11 @@ lint:
     $UV run python scripts/check_test_metadata.py
     {{PRETTIER}} --log-level warn --check {{PRETTIER_PATTERNS}}
 
+# Summarise pytest test metadata (markers + docstrings).
+test-metadata:
+    @echo "Usage: just test-metadata [ARGS='--marker goal_math tests/path']; forwards ARGS to report_test_metadata."
+    $UV run python scripts/report_test_metadata.py {{ARGS}}
+
 # Minimal Ruff diagnostics (E/F/B006/B008).
 # Tip: Catches runtime errors quickly; run `just lint` for policy/doc coverage.
 lint-fast:

--- a/scripts/_test_metadata_helpers.py
+++ b/scripts/_test_metadata_helpers.py
@@ -1,0 +1,102 @@
+"""Shared utilities for inspecting pytest test metadata."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+GOAL_MARKERS = {"goal_math", "goal_code", "goal_performance"}
+
+
+@dataclass
+class TestCase:
+    """Representation of a collected test function."""
+
+    path: Path
+    name: str
+    lineno: int
+    markers: set[str]
+    docstring: str | None
+
+
+def _marker_from_decorator(decorator: ast.AST) -> str | None:
+    """Extract the pytest marker name if the decorator is a goal marker."""
+    target = decorator
+    if isinstance(target, ast.Call):
+        target = target.func
+
+    if isinstance(target, ast.Attribute):
+        if isinstance(target.value, ast.Attribute):
+            if (
+                isinstance(target.value.value, ast.Name)
+                and target.value.value.id == "pytest"
+                and target.value.attr == "mark"
+            ):
+                if target.attr in GOAL_MARKERS:
+                    return target.attr
+    return None
+
+
+def _markers_from_decorators(decorators: Sequence[ast.AST]) -> set[str]:
+    markers: set[str] = set()
+    for decorator in decorators:
+        marker = _marker_from_decorator(decorator)
+        if marker is not None:
+            markers.add(marker)
+    return markers
+
+
+def _collect_tests(
+    node: ast.AST,
+    *,
+    path: Path,
+    parent_markers: Iterable[str] | None = None,
+) -> Iterator[TestCase]:
+    inherited = set(parent_markers or ())
+
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if node.name.startswith("test_"):
+            markers = inherited | _markers_from_decorators(node.decorator_list)
+            docstring = ast.get_docstring(node, clean=False)
+            yield TestCase(
+                path=path,
+                name=node.name,
+                lineno=node.lineno,
+                markers=markers,
+                docstring=docstring,
+            )
+        return
+
+    if isinstance(node, ast.ClassDef):
+        markers = inherited | _markers_from_decorators(node.decorator_list)
+        for child in node.body:
+            yield from _collect_tests(child, path=path, parent_markers=markers)
+        return
+
+    for child in getattr(node, "body", []):
+        yield from _collect_tests(child, path=path, parent_markers=inherited)
+
+
+def iter_test_files(paths: Sequence[str]) -> Iterator[Path]:
+    """Yield python test files under the provided paths."""
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            yield from sorted(path.rglob("test_*.py"))
+        elif path.suffix == ".py":
+            yield path
+
+
+def collect_tests_in_file(path: Path) -> Iterator[TestCase]:
+    """Yield test cases discovered in the given python file."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    yield from _collect_tests(tree, path=path)
+
+
+def iter_test_cases(paths: Sequence[str]) -> Iterator[TestCase]:
+    """Iterate over collected test cases discovered within the provided paths."""
+    for path in iter_test_files(paths):
+        yield from collect_tests_in_file(path)

--- a/scripts/check_test_metadata.py
+++ b/scripts/check_test_metadata.py
@@ -3,91 +3,15 @@
 from __future__ import annotations
 
 import argparse
-import ast
 import sys
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Sequence
 
-GOAL_MARKERS = {"goal_math", "goal_code", "goal_performance"}
-
-
-@dataclass
-class TestCase:
-    """Representation of a collected test function."""
-
-    path: Path
-    name: str
-    lineno: int
-    markers: set[str]
-    docstring: str | None
-
-
-def _marker_from_decorator(decorator: ast.AST) -> str | None:
-    """Extract the pytest marker name if the decorator is a goal marker."""
-    target = decorator
-    if isinstance(target, ast.Call):
-        target = target.func
-
-    if isinstance(target, ast.Attribute):
-        if isinstance(target.value, ast.Attribute):
-            if (
-                isinstance(target.value.value, ast.Name)
-                and target.value.value.id == "pytest"
-                and target.value.attr == "mark"
-            ):
-                if target.attr in GOAL_MARKERS:
-                    return target.attr
-    return None
-
-
-def _markers_from_decorators(decorators: Sequence[ast.AST]) -> set[str]:
-    markers: set[str] = set()
-    for decorator in decorators:
-        marker = _marker_from_decorator(decorator)
-        if marker is not None:
-            markers.add(marker)
-    return markers
-
-
-def _collect_tests(
-    node: ast.AST,
-    *,
-    path: Path,
-    parent_markers: Iterable[str] | None = None,
-) -> Iterable[TestCase]:
-    inherited = set(parent_markers or ())
-
-    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        if node.name.startswith("test_"):
-            markers = inherited | _markers_from_decorators(node.decorator_list)
-            docstring = ast.get_docstring(node, clean=False)
-            yield TestCase(
-                path=path,
-                name=node.name,
-                lineno=node.lineno,
-                markers=markers,
-                docstring=docstring,
-            )
-        return
-
-    if isinstance(node, ast.ClassDef):
-        markers = inherited | _markers_from_decorators(node.decorator_list)
-        for child in node.body:
-            yield from _collect_tests(child, path=path, parent_markers=markers)
-        return
-
-    for child in getattr(node, "body", []):
-        yield from _collect_tests(child, path=path, parent_markers=inherited)
-
-
-def _iter_test_files(paths: Sequence[str]) -> Iterable[Path]:
-    for raw in paths:
-        path = Path(raw)
-        if path.is_dir():
-            yield from sorted(path.rglob("test_*.py"))
-        elif path.suffix == ".py":
-            yield path
+from scripts._test_metadata_helpers import (
+    GOAL_MARKERS,
+    TestCase,
+    collect_tests_in_file,
+    iter_test_files,
+)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -110,11 +34,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     total_tests = 0
     files_scanned = 0
 
-    for path in _iter_test_files(args.paths):
+    for path in iter_test_files(args.paths):
         files_scanned += 1
-        source = path.read_text(encoding="utf-8")
-        tree = ast.parse(source, filename=str(path))
-        for testcase in _collect_tests(tree, path=path):
+        for testcase in collect_tests_in_file(path):
             total_tests += 1
             goal_markers = testcase.markers & GOAL_MARKERS
             if not goal_markers:

--- a/scripts/report_test_metadata.py
+++ b/scripts/report_test_metadata.py
@@ -1,0 +1,77 @@
+"""Report pytest test metadata for quick inspection or scripting."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from scripts._test_metadata_helpers import (
+    GOAL_MARKERS,
+    collect_tests_in_file,
+    iter_test_files,
+)
+
+
+def _docstring_summary(docstring: str | None) -> str:
+    """Extract a single-line summary from a docstring."""
+    if docstring is None:
+        return "(missing docstring)"
+
+    stripped = docstring.strip()
+    if not stripped:
+        return "(missing docstring)"
+
+    first_line = stripped.splitlines()[0].strip()
+    return first_line if first_line else "(missing docstring)"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the metadata reporter CLI."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Emit a stable summary of pytest tests, including their goal markers and docstrings."
+        )
+    )
+    parser.add_argument(
+        "--marker",
+        choices=sorted(GOAL_MARKERS),
+        action="append",
+        dest="markers",
+        help="Filter to tests carrying the specified goal marker (repeatable).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["tests"],
+        help="File or directory roots to scan (default: tests).",
+    )
+    args = parser.parse_args(argv)
+
+    requested_markers = set(args.markers or [])
+
+    entries: list[str] = []
+    for path in iter_test_files(args.paths):
+        for testcase in collect_tests_in_file(path):
+            goal_markers = sorted(testcase.markers & GOAL_MARKERS)
+            if requested_markers and not (requested_markers & set(goal_markers)):
+                continue
+
+            marker_display = "missing"
+            if goal_markers:
+                marker_display = ",".join(goal_markers)
+
+            summary = _docstring_summary(testcase.docstring)
+            entries.append(
+                f"{testcase.path}::{testcase.name} [{marker_display}] - {summary}"
+            )
+
+    entries.sort()
+    print(f"LINES:{len(entries)}")
+    if entries:
+        print("\n".join(entries))
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())

--- a/tests/_utils/test_report_test_metadata.py
+++ b/tests/_utils/test_report_test_metadata.py
@@ -1,0 +1,68 @@
+"""Smoke tests for the test metadata reporting CLI."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from scripts import report_test_metadata
+
+
+@pytest.mark.goal_code
+def test_report_test_metadata_outputs_deterministic_summary(tmp_path, capsys):
+    """Reporter prints deterministic listing with goal marker and docstring summary."""
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text(
+        textwrap.dedent(
+            """
+            import pytest
+
+
+            @pytest.mark.goal_math
+            def test_example():
+                '''Check docstring summary.'''
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = report_test_metadata.main([str(tmp_path)])
+    captured = capsys.readouterr().out.strip().splitlines()
+
+    assert exit_code == 0
+    assert captured[0] == "LINES:1"
+    assert captured[1] == f"{test_file}::test_example [goal_math] - Check docstring summary."
+
+
+@pytest.mark.goal_code
+def test_report_test_metadata_filters_markers(tmp_path, capsys):
+    """Reporter filters tests when marker selector is provided."""
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text(
+        textwrap.dedent(
+            """
+            import pytest
+
+
+            @pytest.mark.goal_code
+            def test_example_code():
+                '''Code test.'''
+
+
+            @pytest.mark.goal_math
+            def test_example_math():
+                '''Math test.'''
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = report_test_metadata.main(["--marker", "goal_math", str(tmp_path)])
+    captured = capsys.readouterr().out.strip().splitlines()
+
+    assert exit_code == 0
+    assert captured[0] == "LINES:1"
+    assert captured[1] == f"{test_file}::test_example_math [goal_math] - Math test."


### PR DESCRIPTION
## Summary
- share the pytest metadata discovery helpers so they can be reused across scripts
- add a report_test_metadata CLI with optional marker filters and wire it into the Justfile workflow
- document the new command in AGENTS.md and add a smoke test to guard the reporter output format

## Testing
- uv run pytest tests/_utils/test_report_test_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68e40dd0b448832bbddd9b74723c1c7c