### PR TITLE
feat: add MILP-based EHZ solvers

### DIFF
--- a/src/viterbo/_wrapped/highs.py
+++ b/src/viterbo/_wrapped/highs.py
@@ -1,0 +1,28 @@
+"""Thin wrapper around :mod:`highspy` to centralise optional imports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HighsResources:
+    """Expose the HiGHS classes required by callers."""
+
+    Highs: type
+    HighsStatus: type
+    HighsModelStatus: type
+    HighsVarType: type
+
+
+def load_highs() -> HighsResources:
+    """Import :mod:`highspy` lazily and return the relevant classes."""
+
+    from highspy import Highs, HighsModelStatus, HighsStatus, HighsVarType
+
+    return HighsResources(
+        Highs=Highs,
+        HighsStatus=HighsStatus,
+        HighsModelStatus=HighsModelStatus,
+        HighsVarType=HighsVarType,
+    )

--- a/src/viterbo/optimization/solvers.py
+++ b/src/viterbo/optimization/solvers.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, Float
 
+from viterbo._wrapped.highs import load_highs
 from viterbo._wrapped.optimize import linprog as _wrapped_linprog
 
 BoundTuple = tuple[float | None, float | None]
@@ -69,13 +70,13 @@ class _HighsResources:
 @lru_cache(1)
 def _load_highs() -> _HighsResources:
     """Load HiGHS classes on-demand."""
-    from highspy import Highs, HighsModelStatus, HighsStatus, HighsVarType
+    resources = load_highs()
 
     return _HighsResources(
-        Highs=Highs,
-        HighsModelStatus=HighsModelStatus,
-        HighsStatus=HighsStatus,
-        HighsVarType=HighsVarType,
+        Highs=resources.Highs,
+        HighsModelStatus=resources.HighsModelStatus,
+        HighsStatus=resources.HighsStatus,
+        HighsVarType=resources.HighsVarType,
     )
 
 

--- a/src/viterbo/symplectic/capacity/__init__.py
+++ b/src/viterbo/symplectic/capacity/__init__.py
@@ -9,9 +9,11 @@ specific algorithms for clarity, e.g.:
 
 from __future__ import annotations
 
-from viterbo.symplectic.capacity.facet_normals.fast import (
-    compute_ehz_capacity_fast as compute_ehz_capacity_fast,
+from viterbo.symplectic.capacity.facet_normals.fast import compute_ehz_capacity_fast
+from viterbo.symplectic.capacity.facet_normals.reference import compute_ehz_capacity_reference
+from viterbo.symplectic.capacity.milp.fast import (
+    compute_ehz_capacity_fast as compute_ehz_capacity_fast_milp,
 )
-from viterbo.symplectic.capacity.facet_normals.reference import (
-    compute_ehz_capacity_reference as compute_ehz_capacity_reference,
+from viterbo.symplectic.capacity.milp.reference import (
+    compute_ehz_capacity_reference as compute_ehz_capacity_reference_milp,
 )

--- a/src/viterbo/symplectic/capacity/milp/__init__.py
+++ b/src/viterbo/symplectic/capacity/milp/__init__.py
@@ -1,0 +1,4 @@
+"""MILP-based solvers for the EHZ capacity."""
+
+from viterbo.symplectic.capacity.milp.fast import compute_ehz_capacity_fast
+from viterbo.symplectic.capacity.milp.reference import compute_ehz_capacity_reference

--- a/src/viterbo/symplectic/capacity/milp/fast.py
+++ b/src/viterbo/symplectic/capacity/milp/fast.py
@@ -1,0 +1,93 @@
+"""Heuristic MILP solver for the EHZ capacity using partial branching."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from viterbo.symplectic.capacity.milp.model import (
+    MilpCapacityResult,
+    MilpCertificate,
+    build_certificate,
+    build_subset_model,
+    solve_subset_model,
+)
+
+
+def compute_ehz_capacity_fast(
+    B_matrix: Float[Array, " num_facets dimension"],
+    c: Float[Array, " num_facets"],
+    *,
+    tol: float = 1e-10,
+    highs_options: Mapping[str, float] | None = None,
+    node_limit: int = 8192,
+) -> MilpCapacityResult:
+    """Search for good MILP certificates via a depth-first subset exploration."""
+
+    B = jnp.asarray(B_matrix, dtype=jnp.float64)
+    offsets = jnp.asarray(c, dtype=jnp.float64)
+
+    if B.ndim != 2:
+        raise ValueError("Facet matrix B must be two-dimensional.")
+
+    if offsets.ndim != 1 or offsets.shape[0] != B.shape[0]:
+        raise ValueError("Vector c must have length equal to the number of facets.")
+
+    num_facets, dimension = B.shape
+    if int(dimension) % 2 != 0 or int(dimension) < 2:
+        raise ValueError("The ambient dimension must satisfy 2n with n >= 1.")
+
+    subset_size = int(dimension) + 1
+    if subset_size > int(num_facets):
+        raise ValueError("Not enough facets to form a candidate subset.")
+
+    priorities = jnp.argsort(-jnp.abs(offsets))
+    ordered_facets: tuple[int, ...] = tuple(int(idx) for idx in priorities)
+
+    stack: list[tuple[tuple[int, ...], int]] = [(tuple(), 0)]
+    expanded_nodes = 0
+    explored = 0
+    best_certificate: MilpCertificate | None = None
+
+    while stack:
+        prefix, start = stack.pop()
+        remaining = subset_size - len(prefix)
+
+        if remaining == 0:
+            subset_indices = tuple(sorted(ordered_facets[position] for position in prefix))
+            model = build_subset_model(B_matrix=B, c=offsets, indices=subset_indices)
+            solution = solve_subset_model(model, options=highs_options)
+            if solution is None:
+                continue
+
+            certificate = build_certificate(model=model, solution=solution, tol=float(tol))
+            explored += 1
+            if certificate is None:
+                continue
+
+            if best_certificate is None or certificate.capacity < best_certificate.capacity:
+                best_certificate = certificate
+            continue
+
+        if node_limit is not None and expanded_nodes >= node_limit and best_certificate is not None:
+            continue
+
+        max_start = int(num_facets) - remaining
+        for position in range(max_start, start - 1, -1):
+            new_prefix = prefix + (position,)
+            stack.append((new_prefix, position + 1))
+            expanded_nodes += 1
+            if node_limit is not None and expanded_nodes >= node_limit:
+                break
+
+    if best_certificate is None:
+        raise ValueError("No admissible facet subset satisfied the MILP constraints.")
+
+    return MilpCapacityResult(
+        upper_bound=float(best_certificate.capacity),
+        lower_bound=None,
+        certificate=best_certificate,
+        explored_subsets=explored,
+    )

--- a/src/viterbo/symplectic/capacity/milp/model.py
+++ b/src/viterbo/symplectic/capacity/milp/model.py
@@ -1,0 +1,182 @@
+"""Shared MILP model construction utilities for EHZ capacity computations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, Float
+
+from viterbo._wrapped.highs import load_highs
+from viterbo.symplectic.capacity.facet_normals.subset_utils import FacetSubset
+from viterbo.symplectic.core import standard_symplectic_matrix
+
+
+@dataclass(frozen=True)
+class SubsetMilpModel:
+    """Dense MILP representation for a fixed facet subset."""
+
+    indices: tuple[int, ...]
+    facet_normals: Float[Array, " subset_size dimension"]
+    support_numbers: Float[Array, " subset_size"]
+
+    @property
+    def subset_size(self) -> int:
+        return int(self.facet_normals.shape[0])
+
+    @property
+    def dimension(self) -> int:
+        return int(self.facet_normals.shape[1])
+
+
+@dataclass(frozen=True)
+class SubsetMilpSolution:
+    """Solution data returned by the HiGHS solve."""
+
+    beta: Float[Array, " subset_size"]
+    objective_value: float
+    status: str
+
+
+@dataclass(frozen=True)
+class MilpCertificate:
+    """Certificate describing an admissible facet subset and action value."""
+
+    subset_indices: tuple[int, ...]
+    beta: Float[Array, " subset_size"]
+    symplectic_products: Float[Array, " subset_size subset_size"]
+    capacity: float
+
+    @property
+    def subset_size(self) -> int:
+        return int(self.beta.shape[0])
+
+
+@dataclass(frozen=True)
+class MilpCapacityResult:
+    """Result of a MILP-based capacity computation."""
+
+    upper_bound: float
+    lower_bound: float | None
+    certificate: MilpCertificate
+    explored_subsets: int
+
+
+def build_subset_model(
+    *,
+    B_matrix: Float[Array, " num_facets dimension"],
+    c: Float[Array, " num_facets"],
+    indices: Iterable[int],
+) -> SubsetMilpModel:
+    """Return the MILP model representing the Reeb constraints for ``indices``."""
+
+    subset = tuple(int(i) for i in indices)
+    rows = jnp.asarray(subset, dtype=int)
+    facet_normals = jnp.asarray(B_matrix)[rows, :]
+    support = jnp.asarray(c)[rows]
+    return SubsetMilpModel(indices=subset, facet_normals=facet_normals, support_numbers=support)
+
+
+def solve_subset_model(
+    model: SubsetMilpModel,
+    *,
+    options: Mapping[str, float] | None = None,
+) -> SubsetMilpSolution | None:
+    """Solve the MILP corresponding to ``model`` using HiGHS."""
+
+    resources = load_highs()
+    highs = resources.Highs()
+    highs.setOptionValue("output_flag", False)
+    highs.setOptionValue("random_seed", 0)
+
+    if options is not None:
+        for key, value in options.items():
+            highs.setOptionValue(str(key), float(value))
+
+    infinity = highs.getInfinity()
+    subset_size = model.subset_size
+    variables = highs.addVariables(
+        range(subset_size),
+        lb=[0.0] * subset_size,
+        ub=[infinity] * subset_size,
+        obj=[0.0] * subset_size,
+        type=[resources.HighsVarType.kContinuous] * subset_size,
+    )
+
+    normals = np.asarray(model.facet_normals, dtype=np.float64)
+    support = np.asarray(model.support_numbers, dtype=np.float64)
+
+    # Equality constraints Σ β_i n_i = 0.
+    for row in normals.T:
+        expression = highs.expr()
+        for column, coefficient in enumerate(row):
+            if coefficient == 0.0:
+                continue
+            expression += float(coefficient) * variables[column]
+        highs.addConstr(expression == 0.0)
+
+    # Normalisation Σ β_i c_i = 1.
+    expression = highs.expr()
+    for column, coefficient in enumerate(support):
+        if coefficient == 0.0:
+            continue
+        expression += float(coefficient) * variables[column]
+    highs.addConstr(expression == 1.0)
+
+    status = highs.minimize()
+    if status != resources.HighsStatus.kOk:
+        return None
+
+    model_status = highs.getModelStatus()
+    if model_status != resources.HighsModelStatus.kOptimal:
+        return None
+
+    solution = highs.getSolution()
+    beta = jnp.asarray(solution.col_value[:subset_size], dtype=jnp.float64)
+    objective_value = float(highs.getObjectiveValue())
+    status_string = str(highs.modelStatusToString(model_status))
+
+    return SubsetMilpSolution(beta=beta, objective_value=objective_value, status=status_string)
+
+
+def build_certificate(
+    *,
+    model: SubsetMilpModel,
+    solution: SubsetMilpSolution,
+    tol: float,
+) -> MilpCertificate | None:
+    """Construct a capacity certificate from a solved subset model."""
+
+    beta = jnp.asarray(solution.beta, dtype=jnp.float64)
+    beta = jnp.where(jnp.abs(beta) <= float(tol), 0.0, beta)
+
+    if bool(jnp.any(beta < -float(tol))):
+        return None
+
+    normals = jnp.asarray(model.facet_normals, dtype=jnp.float64)
+    J = standard_symplectic_matrix(model.dimension)
+    symplectic_products = (normals @ J) @ normals.T
+
+    subset = FacetSubset(
+        indices=model.indices,
+        beta=beta,
+        symplectic_products=symplectic_products,
+    )
+
+    # Evaluate the candidate using the dynamic programming shortcut for robustness.
+    from viterbo.symplectic.capacity.facet_normals.subset_utils import (  # local import for cycle
+        subset_capacity_candidate_dynamic,
+    )
+
+    candidate = subset_capacity_candidate_dynamic(subset, tol=tol)
+    if candidate is None:
+        return None
+
+    return MilpCertificate(
+        subset_indices=model.indices,
+        beta=beta,
+        symplectic_products=symplectic_products,
+        capacity=float(candidate),
+    )

--- a/src/viterbo/symplectic/capacity/milp/reference.py
+++ b/src/viterbo/symplectic/capacity/milp/reference.py
@@ -1,0 +1,69 @@
+"""Reference MILP computation for the EHZ capacity."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from viterbo.symplectic.capacity.facet_normals.subset_utils import iter_index_combinations
+from viterbo.symplectic.capacity.milp.model import (
+    MilpCapacityResult,
+    MilpCertificate,
+    SubsetMilpModel,
+    build_certificate,
+    build_subset_model,
+    solve_subset_model,
+)
+
+
+def compute_ehz_capacity_reference(
+    B_matrix: Float[Array, " num_facets dimension"],
+    c: Float[Array, " num_facets"],
+    *,
+    tol: float = 1e-10,
+    highs_options: Mapping[str, float] | None = None,
+) -> MilpCapacityResult:
+    """Enumerate all facet subsets and return the optimal MILP certificate."""
+
+    B = jnp.asarray(B_matrix, dtype=jnp.float64)
+    offsets = jnp.asarray(c, dtype=jnp.float64)
+
+    if B.ndim != 2:
+        raise ValueError("Facet matrix B must be two-dimensional.")
+
+    if offsets.ndim != 1 or offsets.shape[0] != B.shape[0]:
+        raise ValueError("Vector c must have length equal to the number of facets.")
+
+    num_facets, dimension = B.shape
+    if int(dimension) % 2 != 0 or int(dimension) < 2:
+        raise ValueError("The ambient dimension must satisfy 2n with n >= 1.")
+
+    subset_size = int(dimension) + 1
+    best_certificate: MilpCertificate | None = None
+    explored = 0
+
+    for indices in iter_index_combinations(int(num_facets), subset_size):
+        explored += 1
+        model: SubsetMilpModel = build_subset_model(B_matrix=B, c=offsets, indices=indices)
+        solution = solve_subset_model(model, options=highs_options)
+        if solution is None:
+            continue
+
+        certificate = build_certificate(model=model, solution=solution, tol=float(tol))
+        if certificate is None:
+            continue
+        if best_certificate is None or certificate.capacity < best_certificate.capacity:
+            best_certificate = certificate
+
+    if best_certificate is None:
+        raise ValueError("No admissible facet subset satisfied the MILP constraints.")
+
+    value = float(best_certificate.capacity)
+    return MilpCapacityResult(
+        upper_bound=value,
+        lower_bound=value,
+        certificate=best_certificate,
+        explored_subsets=explored,
+    )

--- a/tests/viterbo/symplectic/capacity/milp/test_benchmark.py
+++ b/tests/viterbo/symplectic/capacity/milp/test_benchmark.py
@@ -1,0 +1,26 @@
+"""Benchmark harness for the MILP reference solver."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from viterbo.geometry.polytopes import simplex_with_uniform_weights
+from viterbo.symplectic.capacity.milp.reference import (
+    compute_ehz_capacity_reference as compute_ehz_capacity_reference_milp,
+)
+
+
+@pytest.fixture(scope="module")
+def benchmark_polytope():
+    return simplex_with_uniform_weights(4, name="milp-benchmark-simplex")
+
+
+def test_reference_solver_benchmark(benchmark, benchmark_polytope) -> None:
+    """Record runtime for the MILP reference solver on a small instance."""
+
+    B, c = benchmark_polytope.halfspace_data()
+
+    result = benchmark(lambda: compute_ehz_capacity_reference_milp(B, c))
+    assert math.isfinite(result.upper_bound)

--- a/tests/viterbo/symplectic/capacity/milp/test_fast.py
+++ b/tests/viterbo/symplectic/capacity/milp/test_fast.py
@@ -1,0 +1,57 @@
+"""Tests for the heuristic MILP solver."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from viterbo.geometry.polytopes import (
+    Polytope,
+    simplex_with_uniform_weights,
+    truncated_simplex_four_dim,
+)
+from viterbo.symplectic.capacity import (
+    compute_ehz_capacity_fast as compute_ehz_capacity_fast_facet,
+    compute_ehz_capacity_reference,
+)
+from viterbo.symplectic.capacity.milp.fast import (
+    compute_ehz_capacity_fast as compute_ehz_capacity_fast_milp,
+)
+
+
+@pytest.fixture(scope="module")
+def four_dimensional_simplex() -> Polytope:
+    return simplex_with_uniform_weights(4, name="milp-fast-simplex")
+
+
+@pytest.fixture(scope="module")
+def truncated_simplex() -> Polytope:
+    return truncated_simplex_four_dim()
+
+
+@pytest.mark.parametrize("polytope_fixture", ["four_dimensional_simplex", "truncated_simplex"])
+def test_fast_solver_matches_reference(
+    polytope_fixture: str, request: pytest.FixtureRequest
+) -> None:
+    """Heuristic solver finds the same certificate as the facet reference on small cases."""
+
+    polytope: Polytope = request.getfixturevalue(polytope_fixture)
+    B, c = polytope.halfspace_data()
+
+    reference_value = compute_ehz_capacity_reference(B, c)
+    fast_result = compute_ehz_capacity_fast_milp(B, c, node_limit=4096)
+
+    assert math.isclose(fast_result.upper_bound, reference_value, rel_tol=0.0, abs_tol=1e-9)
+    assert fast_result.lower_bound is None
+    assert fast_result.explored_subsets >= 1
+
+
+def test_fast_solver_improves_over_facet_fast(four_dimensional_simplex: Polytope) -> None:
+    """MILP heuristic matches or improves the JAX-first fast solver's action."""
+
+    B, c = four_dimensional_simplex.halfspace_data()
+    facet_value = compute_ehz_capacity_fast_facet(B, c)
+    milp_value = compute_ehz_capacity_fast_milp(B, c, node_limit=1024).upper_bound
+
+    assert math.isclose(milp_value, facet_value, rel_tol=0.0, abs_tol=1e-9)

--- a/tests/viterbo/symplectic/capacity/milp/test_reference.py
+++ b/tests/viterbo/symplectic/capacity/milp/test_reference.py
@@ -1,0 +1,68 @@
+"""Tests for the MILP reference solver."""
+
+from __future__ import annotations
+
+import math
+
+import jax.numpy as jnp
+import pytest
+
+from viterbo.geometry.polytopes import (
+    Polytope,
+    simplex_with_uniform_weights,
+    truncated_simplex_four_dim,
+)
+from viterbo.symplectic.capacity import compute_ehz_capacity_reference
+from viterbo.symplectic.capacity.milp.reference import (
+    compute_ehz_capacity_reference as compute_ehz_capacity_reference_milp,
+)
+
+
+@pytest.fixture(scope="module")
+def simplex_polytope() -> Polytope:
+    return simplex_with_uniform_weights(4, name="milp-simplex")
+
+
+@pytest.fixture(scope="module")
+def truncated_simplex() -> Polytope:
+    return truncated_simplex_four_dim()
+
+
+@pytest.mark.parametrize("polytope_fixture", ["simplex_polytope", "truncated_simplex"])
+def test_reference_matches_facet_solution(
+    polytope_fixture: str, request: pytest.FixtureRequest
+) -> None:
+    """Reference MILP solver reproduces the facet-normal optimum."""
+
+    polytope: Polytope = request.getfixturevalue(polytope_fixture)
+    B, c = polytope.halfspace_data()
+
+    facet_value = compute_ehz_capacity_reference(B, c)
+    result = compute_ehz_capacity_reference_milp(B, c)
+
+    assert math.isclose(result.upper_bound, facet_value, rel_tol=0.0, abs_tol=1e-9)
+    assert result.lower_bound is not None
+    assert math.isclose(result.lower_bound, facet_value, rel_tol=0.0, abs_tol=1e-9)
+
+    certificate = result.certificate
+    beta = jnp.asarray(certificate.beta)
+    normals = jnp.asarray(B)[jnp.asarray(certificate.subset_indices), :]
+    support = jnp.asarray(c)[jnp.asarray(certificate.subset_indices)]
+
+    # Verify Reeb-measure feasibility from the certificate.
+    assert bool(jnp.all(beta >= -1e-12))
+    residual = normals.T @ beta
+    assert bool(jnp.all(jnp.isclose(residual, jnp.zeros_like(residual), atol=1e-9, rtol=0.0)))
+    assert math.isclose(float(support @ beta), 1.0, rel_tol=0.0, abs_tol=1e-9)
+
+
+def test_reference_explores_all_subsets(simplex_polytope: Polytope) -> None:
+    """Reference MILP solver enumerates all subsets of size d+1."""
+
+    B, c = simplex_polytope.halfspace_data()
+    num_facets = int(B.shape[0])
+    subset_size = int(B.shape[1]) + 1
+    expected = math.comb(num_facets, subset_size)
+
+    result = compute_ehz_capacity_reference_milp(B, c)
+    assert result.explored_subsets == expected


### PR DESCRIPTION
## Summary
- wrap highspy access and build MILP subset models for EHZ capacity certificates
- add MILP reference enumeration and heuristic fast solver plus top-level exports
- cover the MILP solvers with regression tests and a benchmark harness

## Testing
- uv run pytest tests/viterbo/symplectic/capacity/milp -k "not benchmark"
- uv run pytest tests/viterbo/symplectic/capacity/milp/test_benchmark.py

------
https://chatgpt.com/codex/tasks/task_e_68e403e48b30832bad2ead33c680ba34