### PR TITLE
feat: add support relaxation solvers for EHZ bounds

### DIFF
--- a/src/viterbo/_wrapped/cvx.py
+++ b/src/viterbo/_wrapped/cvx.py
@@ -1,0 +1,49 @@
+"""Thin wrappers around CVXPy with explicit optional-dependency handling."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import numpy as _np
+
+_OPTIMAL_STATUSES = frozenset({"optimal", "optimal_inaccurate"})
+
+
+def _load_cvxpy() -> Any:
+    try:
+        return importlib.import_module("cvxpy")
+    except ModuleNotFoundError as error:  # pragma: no cover - import guard
+        msg = (
+            "cvxpy is required for the reference support-relaxation solver. "
+            "Install the optional dependency or select the fast solver."
+        )
+        raise ModuleNotFoundError(msg) from error
+
+
+def solve_epigraph_minimum(
+    values: Any,
+    *,
+    solver: str,
+    tolerance: float,
+) -> float:
+    """Solve ``min t`` s.t. ``t >= values_i`` using CVXPy."""
+    cvxpy = _load_cvxpy()
+    variable = cvxpy.Variable()
+    constraints = [variable >= float(v) for v in _np.asarray(values, dtype=float)]
+    problem = cvxpy.Problem(cvxpy.Minimize(variable), constraints)
+    options: dict[str, Any] = {}
+    solver_lower = solver.lower()
+    if tolerance > 0.0:
+        if solver_lower == "scs":
+            options["eps_abs"] = tolerance
+            options["eps_rel"] = tolerance
+        elif solver_lower == "ecos":
+            options["abstol"] = tolerance
+            options["reltol"] = tolerance
+    problem.solve(solver=solver, **options)
+    status = problem.status.lower()
+    if status not in _OPTIMAL_STATUSES:
+        msg = f"CVXPy solver failed with status {problem.status}."
+        raise RuntimeError(msg)
+    return float(variable.value)

--- a/src/viterbo/symplectic/capacity/__init__.py
+++ b/src/viterbo/symplectic/capacity/__init__.py
@@ -15,3 +15,9 @@ from viterbo.symplectic.capacity.facet_normals.fast import (
 from viterbo.symplectic.capacity.facet_normals.reference import (
     compute_ehz_capacity_reference as compute_ehz_capacity_reference,
 )
+from viterbo.symplectic.capacity.support_relaxation.fast import (
+    compute_support_relaxation_capacity_fast as compute_support_relaxation_capacity_fast,
+)
+from viterbo.symplectic.capacity.support_relaxation.reference import (
+    compute_support_relaxation_capacity_reference as compute_support_relaxation_capacity_reference,
+)

--- a/src/viterbo/symplectic/capacity/support_relaxation/__init__.py
+++ b/src/viterbo/symplectic/capacity/support_relaxation/__init__.py
@@ -1,0 +1,19 @@
+"""Support-function relaxations for EHZ capacity upper bounds."""
+
+from __future__ import annotations
+
+from viterbo.symplectic.capacity.support_relaxation.fast import (
+    SupportRelaxationDiagnostics,
+    SupportRelaxationResult,
+    compute_support_relaxation_capacity_fast,
+)
+from viterbo.symplectic.capacity.support_relaxation.reference import (
+    compute_support_relaxation_capacity_reference,
+)
+
+__all__ = [
+    "compute_support_relaxation_capacity_fast",
+    "compute_support_relaxation_capacity_reference",
+    "SupportRelaxationDiagnostics",
+    "SupportRelaxationResult",
+]

--- a/src/viterbo/symplectic/capacity/support_relaxation/fast.py
+++ b/src/viterbo/symplectic/capacity/support_relaxation/fast.py
@@ -1,0 +1,125 @@
+"""Accelerated solver for support-function relaxations of ``c_EHZ``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from viterbo.symplectic.capacity.support_relaxation import kernels
+
+
+@dataclass(frozen=True)
+class SupportRelaxationDiagnostics:
+    """Single iteration diagnostics for continuation and refinement."""
+
+    grid_density: int
+    smoothing_parameter: float
+    smoothing_strength: float
+    tolerance: float
+    candidate_capacity: float
+
+
+@dataclass(frozen=True)
+class SupportRelaxationResult:
+    """Result of the support-function relaxation algorithm."""
+
+    capacity_upper_bound: float
+    history: tuple[SupportRelaxationDiagnostics, ...]
+
+
+def _prepare_vertices(
+    vertices: Float[Array, " num_vertices dimension"],
+    *,
+    center_vertices: bool,
+) -> Float[Array, " num_vertices dimension"]:
+    vertices = kernels.validate_vertices(vertices)
+    if center_vertices:
+        centre = jnp.mean(vertices, axis=0)
+        vertices = vertices - centre
+    return vertices
+
+
+def _compute_candidate(
+    vertices: Float[Array, " num_vertices dimension"],
+    directions: Float[Array, " num_directions dimension"],
+    *,
+    strength: float,
+) -> Float[Array, ""]:
+    products = kernels.support_products(vertices, directions)
+    smoothed = kernels.smooth_support_products(products, strength=strength)
+    candidate = jnp.pi * jnp.max(smoothed)
+    return candidate
+
+
+def compute_support_relaxation_capacity_fast(
+    vertices: Float[Array, " num_vertices dimension"],
+    *,
+    initial_density: int = 7,
+    refinement_steps: int = 3,
+    refinement_growth: int = 2,
+    smoothing_parameters: Iterable[float] = (0.9, 0.6, 0.3, 0.0),
+    tolerance_sequence: Sequence[float] = (1e-3, 1e-4, 1e-5),
+    log_callback: Callable[[SupportRelaxationDiagnostics], None] | None = None,
+    center_vertices: bool = True,
+    jit_compile: bool = True,
+) -> SupportRelaxationResult:
+    """Compute an upper bound on ``c_EHZ`` using adaptive support relaxations."""
+    vertices = _prepare_vertices(vertices, center_vertices=center_vertices)
+
+    smoothing_schedule = kernels.continuation_schedule(smoothing_parameters)
+    tolerance_sequence = tuple(float(t) for t in tolerance_sequence)
+    if not tolerance_sequence:
+        tolerance_sequence = (0.0,)
+
+    history: list[SupportRelaxationDiagnostics] = []
+    best_value = float("inf")
+
+    candidate_function = _compute_candidate
+    if jit_compile:
+        candidate_function = jax.jit(
+            _compute_candidate,
+            static_argnames=("strength",),
+        )
+
+    for stage, parameter in enumerate(smoothing_schedule):
+        strength = kernels.smoothing_strength(parameter)
+        density = initial_density
+        tolerance = tolerance_sequence[min(stage, len(tolerance_sequence) - 1)]
+        previous = float("inf")
+
+        for _ in range(refinement_steps):
+            directions = kernels.grid_directions(vertices.shape[1], density=density)
+            candidate_value = candidate_function(
+                vertices,
+                directions,
+                strength=strength,
+            )
+            candidate = float(candidate_value)
+            best_value = min(best_value, candidate)
+            history.append(
+                SupportRelaxationDiagnostics(
+                    grid_density=density,
+                    smoothing_parameter=parameter,
+                    smoothing_strength=strength,
+                    tolerance=tolerance,
+                    candidate_capacity=best_value,
+                )
+            )
+            if log_callback is not None:
+                log_callback(history[-1])
+
+            if previous - candidate <= tolerance * max(1.0, candidate):
+                break
+
+            previous = candidate
+            density += refinement_growth
+
+    result = SupportRelaxationResult(
+        capacity_upper_bound=best_value,
+        history=tuple(history),
+    )
+    return result

--- a/src/viterbo/symplectic/capacity/support_relaxation/kernels.py
+++ b/src/viterbo/symplectic/capacity/support_relaxation/kernels.py
@@ -1,0 +1,113 @@
+"""Direction sampling and smoothing kernels for support relaxations."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array, Float
+
+from viterbo.symplectic.core import standard_symplectic_matrix
+
+
+def validate_vertices(
+    vertices: Float[Array, " num_vertices dimension"],
+) -> Float[Array, " num_vertices dimension"]:
+    """Validate vertex array shape and ensure an even ambient dimension."""
+    vertices = jnp.asarray(vertices, dtype=jnp.float64)
+    if vertices.ndim != 2 or vertices.shape[0] == 0:
+        msg = "Support relaxation expects a non-empty (num_vertices, dimension) array."
+        raise ValueError(msg)
+    if vertices.shape[1] % 2 != 0:
+        msg = "Support relaxation requires an even ambient dimension."
+        raise ValueError(msg)
+    return vertices
+
+
+def grid_directions(
+    dimension: int,
+    *,
+    density: int,
+) -> Float[Array, " num_directions dimension"]:
+    """Return approximately uniform directions on the d-dimensional cube grid."""
+    if dimension <= 0:
+        msg = "Dimension must be positive."
+        raise ValueError(msg)
+    if density < 2:
+        msg = "Grid density must be at least 2."
+        raise ValueError(msg)
+
+    axes = [
+        np.linspace(-1.0, 1.0, density, dtype=np.float64) for _ in range(dimension)
+    ]
+    mesh = np.stack(np.meshgrid(*axes, indexing="ij"), axis=-1).reshape(-1, dimension)
+    norms = np.linalg.norm(mesh, axis=1)
+    mask = norms > 1e-12
+    filtered = mesh[mask]
+    norms = norms[mask][:, None]
+    normalised = filtered / norms
+    # Remove duplicate rows caused by the projection of antipodal points.
+    normalised = np.unique(np.round(normalised, decimals=12), axis=0)
+    result: Float[Array, " num_directions dimension"] = jnp.asarray(
+        normalised, dtype=jnp.float64
+    )
+    return result
+
+
+def support_products(
+    vertices: Float[Array, " num_vertices dimension"],
+    directions: Float[Array, " num_directions dimension"],
+) -> Float[Array, " num_directions"]:
+    """Return ``h_K(u) * h_K(Ju)`` for all sampled directions."""
+    vertices = validate_vertices(vertices)
+    directions = jnp.asarray(directions, dtype=jnp.float64)
+    if directions.ndim != 2 or directions.shape[0] == 0:
+        msg = "Direction grid must be two-dimensional and non-empty."
+        raise ValueError(msg)
+    if directions.shape[1] != vertices.shape[1]:
+        msg = "Directions and vertices must share the same ambient dimension."
+        raise ValueError(msg)
+
+    symplectic = standard_symplectic_matrix(vertices.shape[1])
+
+    support_values = jnp.max(vertices @ directions.T, axis=0)
+    rotated = directions @ symplectic.T
+    rotated_support = jnp.max(vertices @ rotated.T, axis=0)
+    products: Float[Array, " num_directions"] = support_values * rotated_support
+    return products
+
+
+def smoothing_strength(parameter: float) -> float:
+    """Map a smoothing parameter to a convex-combination weight in ``[0, 1)``."""
+    if parameter < 0.0:
+        msg = "Smoothing parameter must be non-negative."
+        raise ValueError(msg)
+    strength = 1.0 - float(np.exp(-parameter))
+    return strength
+
+
+def smooth_support_products(
+    products: Float[Array, " num_directions"],
+    *,
+    strength: float,
+) -> Float[Array, " num_directions"]:
+    """Interpolate support products towards their global maximum."""
+    if not 0.0 <= strength < 1.0:
+        msg = "Smoothing strength must lie in [0, 1)."
+        raise ValueError(msg)
+    products = jnp.asarray(products, dtype=jnp.float64)
+    maximum = jnp.max(products)
+    smoothed = (1.0 - strength) * products + strength * maximum
+    return smoothed
+
+
+def continuation_schedule(
+    parameters: Iterable[float],
+) -> tuple[float, ...]:
+    """Return a monotone non-increasing schedule suitable for continuation."""
+    values = tuple(float(p) for p in parameters)
+    if any(p < 0.0 for p in values):
+        msg = "Continuation parameters must be non-negative."
+        raise ValueError(msg)
+    return tuple(sorted(values, reverse=True))

--- a/src/viterbo/symplectic/capacity/support_relaxation/reference.py
+++ b/src/viterbo/symplectic/capacity/support_relaxation/reference.py
@@ -1,0 +1,93 @@
+"""Reference solver relying on CVX for the support-function relaxation."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Sequence
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from viterbo._wrapped import cvx
+from viterbo.symplectic.capacity.support_relaxation import kernels
+from viterbo.symplectic.capacity.support_relaxation.fast import (
+    SupportRelaxationDiagnostics,
+    SupportRelaxationResult,
+)
+
+
+def _prepare_vertices(
+    vertices: Float[Array, " num_vertices dimension"],
+    *,
+    center_vertices: bool,
+) -> Float[Array, " num_vertices dimension"]:
+    vertices = kernels.validate_vertices(vertices)
+    if center_vertices:
+        centre = jnp.mean(vertices, axis=0)
+        vertices = vertices - centre
+    return vertices
+
+
+def _solve_convex_epigraph(
+    products: Float[Array, " num_directions"],
+    *,
+    solver: str,
+    tolerance: float,
+) -> float:
+    objective = jnp.asarray(products, dtype=jnp.float64)
+    value = cvx.solve_epigraph_minimum(objective, solver=solver, tolerance=tolerance)
+    return float(value)
+
+
+def compute_support_relaxation_capacity_reference(
+    vertices: Float[Array, " num_vertices dimension"],
+    *,
+    grid_density: int = 9,
+    smoothing_parameters: Iterable[float] = (1.0, 0.7, 0.4, 0.2, 0.0),
+    tolerance_sequence: Sequence[float] = (1e-4, 1e-5, 1e-6),
+    solver: str = "SCS",
+    log_callback: Callable[[SupportRelaxationDiagnostics], None] | None = None,
+    center_vertices: bool = True,
+) -> SupportRelaxationResult:
+    """Solve the relaxed convex program using CVXPy."""
+    vertices = _prepare_vertices(vertices, center_vertices=center_vertices)
+
+    smoothing_schedule = kernels.continuation_schedule(smoothing_parameters)
+    tolerance_sequence = tuple(float(t) for t in tolerance_sequence)
+    if not tolerance_sequence:
+        tolerance_sequence = (0.0,)
+
+    directions = kernels.grid_directions(vertices.shape[1], density=grid_density)
+    base_products = kernels.support_products(vertices, directions)
+
+    history: list[SupportRelaxationDiagnostics] = []
+    best_value = float("inf")
+
+    for stage, parameter in enumerate(smoothing_schedule):
+        strength = kernels.smoothing_strength(parameter)
+        tolerance = tolerance_sequence[min(stage, len(tolerance_sequence) - 1)]
+        products = kernels.smooth_support_products(base_products, strength=strength)
+        candidate = float(
+            jnp.pi
+            * _solve_convex_epigraph(
+                products,
+                solver=solver,
+                tolerance=tolerance,
+            )
+        )
+        best_value = min(best_value, candidate)
+        diagnostics = SupportRelaxationDiagnostics(
+            grid_density=grid_density,
+            smoothing_parameter=parameter,
+            smoothing_strength=strength,
+            tolerance=tolerance,
+            candidate_capacity=best_value,
+        )
+        history.append(diagnostics)
+        if log_callback is not None:
+            log_callback(diagnostics)
+
+    result = SupportRelaxationResult(
+        capacity_upper_bound=best_value,
+        history=tuple(history),
+    )
+    return result

--- a/tests/viterbo/symplectic/capacity/support_relaxation/conftest.py
+++ b/tests/viterbo/symplectic/capacity/support_relaxation/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+
+@pytest.fixture()
+def unit_disk_vertices() -> jnp.ndarray:
+    angles = jnp.linspace(0.0, 2.0 * jnp.pi, 128, endpoint=False)
+    vertices = jnp.stack((jnp.cos(angles), jnp.sin(angles)), axis=1)
+    return jnp.asarray(vertices, dtype=jnp.float64)

--- a/tests/viterbo/symplectic/capacity/support_relaxation/test_fast.py
+++ b/tests/viterbo/symplectic/capacity/support_relaxation/test_fast.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from viterbo.symplectic.capacity.support_relaxation.fast import (
+    SupportRelaxationDiagnostics,
+    compute_support_relaxation_capacity_fast,
+)
+
+
+def _assert_monotone(history: list[float]) -> None:
+    for left, right in zip(history, history[1:]):
+        assert left + 1e-12 >= right
+
+
+def test_fast_solver_converges_on_unit_disk(unit_disk_vertices) -> None:
+    logs: list[SupportRelaxationDiagnostics] = []
+    result = compute_support_relaxation_capacity_fast(
+        unit_disk_vertices,
+        initial_density=9,
+        refinement_steps=2,
+        smoothing_parameters=(0.9, 0.6, 0.3, 0.1, 0.0),
+        tolerance_sequence=(1e-3, 1e-4, 1e-5),
+        log_callback=logs.append,
+        jit_compile=False,
+    )
+    assert logs, "log_callback should record diagnostics"
+    capacities = [diagnostic.candidate_capacity for diagnostic in result.history]
+    _assert_monotone(capacities)
+    assert capacities[-1] == pytest.approx(result.capacity_upper_bound)
+    assert result.capacity_upper_bound == pytest.approx(math.pi, rel=7e-2)
+
+
+def test_fast_solver_translation_invariant(unit_disk_vertices) -> None:
+    base = compute_support_relaxation_capacity_fast(unit_disk_vertices, jit_compile=False)
+    translated = compute_support_relaxation_capacity_fast(
+        unit_disk_vertices + 0.75,
+        jit_compile=False,
+    )
+    assert translated.capacity_upper_bound == pytest.approx(
+        base.capacity_upper_bound, rel=1e-9
+    )

--- a/tests/viterbo/symplectic/capacity/support_relaxation/test_reference.py
+++ b/tests/viterbo/symplectic/capacity/support_relaxation/test_reference.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import math
+from typing import Final
+
+import pytest
+
+from viterbo.symplectic.capacity.support_relaxation.reference import (
+    compute_support_relaxation_capacity_reference,
+)
+
+_: Final = pytest.importorskip("cvxpy")
+
+
+def _assert_monotone(history: list[float]) -> None:
+    for left, right in zip(history, history[1:]):
+        assert left + 1e-12 >= right
+
+
+def test_reference_solver_converges_on_unit_disk(unit_disk_vertices) -> None:
+    result = compute_support_relaxation_capacity_reference(
+        unit_disk_vertices,
+        grid_density=15,
+        smoothing_parameters=(1.2, 0.9, 0.6, 0.3, 0.1, 0.0),
+        tolerance_sequence=(1e-5, 1e-6, 1e-6),
+    )
+    capacities = [diagnostic.candidate_capacity for diagnostic in result.history]
+    _assert_monotone(capacities)
+    assert capacities[-1] == pytest.approx(result.capacity_upper_bound)
+    assert result.capacity_upper_bound == pytest.approx(math.pi, rel=5e-2)
+
+
+def test_reference_solver_translation_invariant(unit_disk_vertices) -> None:
+    base = compute_support_relaxation_capacity_reference(unit_disk_vertices)
+    translated = compute_support_relaxation_capacity_reference(
+        unit_disk_vertices + 0.25,
+    )
+    assert translated.capacity_upper_bound == pytest.approx(
+        base.capacity_upper_bound, rel=1e-9
+    )


### PR DESCRIPTION
## Summary
- add support-relaxation kernels plus fast/reference solvers for upper bounds on c_EHZ
- introduce a thin cvxpy wrapper to handle optional dependency loading and solver tolerances
- cover the solvers with unit tests exercising monotone convergence, invariance, and logging hooks

## Testing
- `uv run pytest tests/viterbo/symplectic/capacity/support_relaxation`


------
https://chatgpt.com/codex/tasks/task_e_68e403e99f08832b95e03fcc4edbfda2