### PR TITLE
feat(symplectic): add reeb cycle graph scaffolding

### DIFF
--- a/docs/tasks/draft/2025-10-06-reeb-cycle-enumeration.md
+++ b/docs/tasks/draft/2025-10-06-reeb-cycle-enumeration.md
@@ -1,0 +1,79 @@
+# Chaidez–Hutchings Reeb-cycle solver implementation
+
+- **Status**: Draft
+- **Last updated**: 2025-10-06
+- **Owner / DRI**: Codex agent
+- **Reviewers**: Unassigned
+- **Related docs**: [Reeb orbit cross-check (E2)](2025-10-04-reeb-cross-check.md)
+
+## 1. Context and intent
+
+The current `reeb_cycles` package builds the oriented-edge graph for 4D polytopes but both the `reference` and `fast` entry points simply validate connectivity before deferring to the existing facet-normal solvers.【F:src/viterbo/symplectic/capacity/reeb_cycles/reference.py†L9-L24】【F:src/viterbo/symplectic/capacity/reeb_cycles/fast.py†L9-L27】 This leaves us unable to cross-check Chaidez–Hutchings combinatorial cycles against facet normals or to evaluate the performance gap between a faithful reference algorithm and an optimized version.
+
+Implementing the real Chaidez–Hutchings pipeline requires reconstructing the admissible cycle enumeration (DFS/Johnson), computing the combinatorial action with exact rational arithmetic, and enforcing the admissibility filters tied to the polytope facets. The blocker is the absence of a precise, codified description of the action functional and transition matrices derived from the paper; the existing code only exposes graph structure without the cycle weights.【F:src/viterbo/symplectic/capacity/reeb_cycles/graph.py†L13-L118】
+
+## 2. Objectives and non-goals
+
+### In scope
+
+- Implement a readable reference solver that enumerates admissible cycles using NetworkX DFS/Johnson’s algorithm and evaluates Chaidez–Hutchings action exactly.
+- Implement the fast solver with bitset transitions, pruning heuristics, and Johnson’s algorithm for cycle enumeration.
+- Validate both solvers against facet-normal capacities on Chaidez–Hutchings benchmark polytopes.
+- Document algorithm invariants and numerical assumptions so future maintainers can audit the pipeline.
+
+### Out of scope
+
+- Extending the oriented-edge framework beyond 4D polytopes.
+- Replacing the existing facet-normal solvers or changing their APIs.
+- Shipping GPU/JIT acceleration beyond the requested bitset/Johnson optimizations.
+
+## 3. Deliverables and exit criteria
+
+- Production-quality reference and fast implementations in `reeb_cycles/reference.py` and `reeb_cycles/fast.py` that return capacities without delegating to facet-normal solvers.
+- Unit and regression tests in `tests/viterbo/symplectic/capacity/reeb_cycles/` covering Chaidez–Hutchings fixtures plus parity checks against facet-normal outputs.
+- Performance benchmarks quantifying the speed-up of the fast solver relative to the reference implementation on representative 4D polytopes.
+- Narrative documentation (README or module docstrings) explaining admissibility rules, action evaluation, and pruning heuristics.
+
+Exit criteria: both solvers pass the new tests, match facet-normal capacities within tolerance, and benchmarks demonstrate the intended performance characteristics.
+
+## 4. Dependencies and prerequisites
+
+- Authoritative specification or reference implementation of the Chaidez–Hutchings combinatorial action and admissibility filters. Without this, the action weights and pruning rules remain ambiguous (current blocker).
+- Confirmed dataset of Chaidez–Hutchings benchmark polytopes with facet data and expected capacities.
+- Validation that the existing oriented-edge graph data structure captures all metadata required for action evaluation (e.g., affine transition matrices, orientation signs).
+
+## 5. Execution plan and checkpoints
+
+1. Acquire or derive the explicit formulas for action computation and admissibility, and validate them against a single benchmark polytope.
+2. Implement the reference solver with exact rational arithmetic (e.g., `fractions.Fraction` or `sympy`) and DFS/Johnson enumeration; add focused unit tests.
+3. Profile the reference solver on benchmark fixtures to identify performance bottlenecks.
+4. Implement the fast solver with bitset encoding, Johnson’s algorithm, and pruning heuristics; cross-validate results with the reference solver.
+5. Expand regression tests and benchmarks, documenting observed performance deltas and any numeric stability considerations.
+
+## 6. Effort and resource estimates
+
+- Agent time: High (deriving the formulas, implementing two solvers, and authoring tests/benchmarks).
+- Compute budget: Medium (cycle enumeration can be expensive but tractable for benchmark-sized polytopes).
+- Expert/PI involvement: High (required to provide or validate the Chaidez–Hutchings specification and benchmark dataset).
+
+Reevaluate after Step 2; if the specification is still unclear, escalate with a `Needs-Unblock: Chaidez–Hutchings spec` update.
+
+## 7. Testing, benchmarks, and verification
+
+- CI: `just precommit` (lint, typecheck, smoke tests) must pass with the new solvers.
+- Unit tests: targeted suites under `tests/viterbo/symplectic/capacity/reeb_cycles/` covering cycle enumeration, action evaluation, and parity with facet-normal capacities.
+- Benchmarks: extend `tests/performance/.../reeb_cycles/` to record runtime comparisons; capture artefacts via the existing benchmarking harness.
+
+## 8. Risks, mitigations, and escalation triggers
+
+- **Specification ambiguity (current blocker)**: without the explicit action formulas, implementations risk being incorrect. Mitigation: obtain PI guidance or external references before coding; escalate if unavailable.
+- **Combinatorial explosion**: cycle enumeration may be infeasible for larger polytopes. Mitigation: introduce early pruning heuristics and document practical limits.
+- **Numeric drift**: floating-point approximations may break admissibility checks. Mitigation: use rational arithmetic in the reference solver and only downcast in the fast solver with documented tolerances.
+
+Escalate if action formulas cannot be validated on at least one benchmark or if runtime exceeds benchmark budgets by >10× compared to facet-normal solvers.
+
+## 9. Follow-on work
+
+- Generalise the oriented-edge framework to higher dimensions once the 4D pipeline is trusted.
+- Explore hybrid solvers that blend facet-normal and Reeb-cycle information for better performance.
+- Publish a methodological note summarising lessons from implementing combinatorial Reeb-cycle capacities.

--- a/docs/tasks/draft/index.md
+++ b/docs/tasks/draft/index.md
@@ -10,3 +10,4 @@ Draft proposals and experiments under consideration.
 - [MILP solver selection (E3a)](2025-10-05-milp-solver-selection.md)
 - [Benchmark marker strategy (T2a)](2025-10-05-benchmark-marker-strategy.md)
 - [Testing, benchmarking, and regression program (T2/T2a/T3)](2025-10-06-testing-benchmark-regression-program.md)
+- [Chaidez–Hutchings Reeb-cycle solver implementation](2025-10-06-reeb-cycle-enumeration.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "jaxopt>=0.8.5",
     "jaxtyping>=0.3.3",
     "numpy>=2.3.3",
+    "networkx>=3.2.1",
     "orbax-checkpoint>=0.11.25",
     "pyarrow>=21.0.0",
     "scipy>=1.16.2",

--- a/src/viterbo/symplectic/capacity/__init__.py
+++ b/src/viterbo/symplectic/capacity/__init__.py
@@ -9,6 +9,12 @@ specific algorithms for clarity, e.g.:
 
 from __future__ import annotations
 
+from viterbo.symplectic.capacity.reeb_cycles.fast import (
+    compute_ehz_capacity_fast as compute_ehz_capacity_reeb_fast,
+)
+from viterbo.symplectic.capacity.reeb_cycles.reference import (
+    compute_ehz_capacity_reference as compute_ehz_capacity_reeb_reference,
+)
 from viterbo.symplectic.capacity.facet_normals.fast import (
     compute_ehz_capacity_fast as compute_ehz_capacity_fast,
 )

--- a/src/viterbo/symplectic/capacity/reeb_cycles/__init__.py
+++ b/src/viterbo/symplectic/capacity/reeb_cycles/__init__.py
@@ -1,0 +1,15 @@
+"""Chaidez–Hutchings combinatorial Reeb cycle utilities."""
+
+from __future__ import annotations
+
+from viterbo.symplectic.capacity.reeb_cycles.fast import (
+    compute_ehz_capacity_fast,
+)
+from viterbo.symplectic.capacity.reeb_cycles.reference import (
+    compute_ehz_capacity_reference,
+)
+
+__all__ = [
+    "compute_ehz_capacity_reference",
+    "compute_ehz_capacity_fast",
+]

--- a/src/viterbo/symplectic/capacity/reeb_cycles/fast.py
+++ b/src/viterbo/symplectic/capacity/reeb_cycles/fast.py
@@ -1,0 +1,35 @@
+"""Optimized wrapper delegating to the facet-normal EHZ solver."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from jaxtyping import Array, Float
+
+from viterbo.symplectic.capacity.facet_normals.fast import (
+    compute_ehz_capacity_fast as _facet_fast,
+)
+from viterbo.symplectic.capacity.facet_normals.reference import (
+    compute_ehz_capacity_reference as _facet_reference,
+)
+from viterbo.symplectic.capacity.reeb_cycles.graph import build_oriented_edge_graph
+
+
+def compute_ehz_capacity_fast(
+    B_matrix: Float[Array, " num_facets dimension"],
+    c_vector: Float[Array, " num_facets"],
+    *,
+    atol: float = 1e-9,
+) -> float:
+    """Compute ``c_EHZ`` via the fast facet-normal search after graph validation."""
+
+    graph = build_oriented_edge_graph(B_matrix, c_vector, atol=atol)
+    if graph.graph.number_of_nodes() == 0:
+        raise ValueError("Oriented-edge graph is empty; polytope lacks admissible edges.")
+    try:
+        return _facet_fast(B_matrix, c_vector)
+    except ValueError:
+        return _facet_reference(B_matrix, c_vector)
+
+
+__all__: Final = ["compute_ehz_capacity_fast"]

--- a/src/viterbo/symplectic/capacity/reeb_cycles/graph.py
+++ b/src/viterbo/symplectic/capacity/reeb_cycles/graph.py
@@ -1,0 +1,169 @@
+"""Oriented-edge graph construction for combinatorial Reeb cycles."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Final
+
+import jax.numpy as jnp
+import networkx as nx
+from jaxtyping import Array, Float
+
+from viterbo.geometry.polytopes import Polytope, polytope_combinatorics
+
+
+@dataclass(frozen=True)
+class OrientedEdge:
+    """Directed edge on the Chaidez–Hutchings oriented-edge graph."""
+
+    identifier: int
+    facets: tuple[int, int, int]
+    tail_vertex: int
+    head_vertex: int
+    tail_missing_facet: int
+    head_missing_facet: int
+
+
+@dataclass(frozen=True)
+class OrientedEdgeGraph:
+    """Container bundling the oriented-edge graph with metadata."""
+
+    graph: nx.DiGraph
+    edges: tuple[OrientedEdge, ...]
+    dimension: int
+
+    def outgoing(self, edge_id: int) -> list[int]:
+        """Return identifiers of edges admissible after ``edge_id``."""
+
+        return list(self.graph.successors(edge_id))
+
+    def incoming(self, edge_id: int) -> list[int]:
+        """Return identifiers of edges leading into ``edge_id``."""
+
+        return list(self.graph.predecessors(edge_id))
+
+
+def _vertex_key(vertex: jnp.ndarray, *, atol: float) -> tuple[int, ...]:
+    scaled = jnp.asarray(jnp.round(vertex / float(atol))).astype(int)
+    return tuple(int(x) for x in scaled.tolist())
+
+
+def build_oriented_edge_graph(
+    B_matrix: Float[Array, " num_facets dimension"],
+    c_vector: Float[Array, " num_facets"],
+    *,
+    atol: float = 1e-9,
+) -> OrientedEdgeGraph:
+    """Construct the oriented-edge transition graph from ``(B, c)``."""
+
+    B = jnp.asarray(B_matrix, dtype=jnp.float64)
+    c = jnp.asarray(c_vector, dtype=jnp.float64)
+    if B.ndim != 2:
+        msg = "Facet matrix must be two-dimensional."
+        raise ValueError(msg)
+    if c.ndim != 1 or c.shape[0] != B.shape[0]:
+        msg = "Offsets must match the number of facets."
+        raise ValueError(msg)
+
+    dimension = int(B.shape[1])
+    if dimension != 4:
+        msg = "Combinatorial Reeb cycles are only implemented for dimension four."
+        raise ValueError(msg)
+
+    polytope = Polytope(name="temporary-reeb", B=B, c=c)
+    combinatorics = polytope_combinatorics(polytope, atol=atol, use_cache=False)
+
+    vertex_lookup: dict[tuple[int, ...], int] = {}
+    for index, vertex in enumerate(combinatorics.vertices):
+        vertex_lookup[_vertex_key(vertex, atol=atol)] = index
+
+    incident_edges: dict[int, list[int]] = defaultdict(list)
+    reverse_incident: dict[int, list[int]] = defaultdict(list)
+    triple_vertices: dict[tuple[int, int, int], list[int]] = defaultdict(list)
+    missing_facets: dict[tuple[tuple[int, int, int], int], int] = {}
+
+    for cone in combinatorics.normal_cones:
+        key = _vertex_key(cone.vertex, atol=atol)
+        if key not in vertex_lookup:
+            continue
+        vertex_index = vertex_lookup[key]
+        active = tuple(cone.active_facets)
+        if len(active) != dimension:
+            # Chaidez–Hutchings assumes simple polytopes; skip degenerate vertices.
+            continue
+        for triple in combinations(sorted(active), 3):
+            remainder = sorted(set(active) - set(triple))
+            if len(remainder) != 1:
+                continue
+            triple_vertices[triple].append(vertex_index)
+            missing_facets[(triple, vertex_index)] = remainder[0]
+
+    oriented_edges: list[OrientedEdge] = []
+    graph = nx.DiGraph()
+
+    for triple, vertices in triple_vertices.items():
+        if len(vertices) != 2:
+            continue
+        first, second = vertices
+        tail_missing = missing_facets.get((triple, first))
+        head_missing = missing_facets.get((triple, second))
+        if tail_missing is None or head_missing is None:
+            continue
+        identifier = len(oriented_edges)
+        edge = OrientedEdge(
+            identifier=identifier,
+            facets=triple,
+            tail_vertex=first,
+            head_vertex=second,
+            tail_missing_facet=tail_missing,
+            head_missing_facet=head_missing,
+        )
+        oriented_edges.append(edge)
+        graph.add_node(identifier)
+        incident_edges[first].append(identifier)
+        reverse_incident[second].append(identifier)
+
+        identifier_rev = len(oriented_edges)
+        reverse_edge = OrientedEdge(
+            identifier=identifier_rev,
+            facets=triple,
+            tail_vertex=second,
+            head_vertex=first,
+            tail_missing_facet=head_missing,
+            head_missing_facet=tail_missing,
+        )
+        oriented_edges.append(reverse_edge)
+        graph.add_node(identifier_rev)
+        incident_edges[second].append(identifier_rev)
+        reverse_incident[first].append(identifier_rev)
+
+    for vertex_index in range(len(combinatorics.vertices)):
+        incoming = reverse_incident.get(vertex_index, [])
+        outgoing = incident_edges.get(vertex_index, [])
+        if not incoming or not outgoing:
+            continue
+        for source in incoming:
+            edge_in = oriented_edges[source]
+            for target in outgoing:
+                edge_out = oriented_edges[target]
+                if source == target:
+                    continue
+                if edge_in.tail_vertex == edge_out.head_vertex and edge_in.facets == edge_out.facets:
+                    continue
+                shared_facets = set(edge_in.facets).intersection(edge_out.facets)
+                if len(shared_facets) != 2:
+                    continue
+                if edge_in.head_missing_facet == edge_out.tail_missing_facet:
+                    continue
+                graph.add_edge(source, target)
+
+    return OrientedEdgeGraph(
+        graph=graph,
+        edges=tuple(oriented_edges),
+        dimension=dimension,
+    )
+
+
+__all__: Final = ["OrientedEdge", "OrientedEdgeGraph", "build_oriented_edge_graph"]

--- a/src/viterbo/symplectic/capacity/reeb_cycles/reference.py
+++ b/src/viterbo/symplectic/capacity/reeb_cycles/reference.py
@@ -1,0 +1,29 @@
+"""Reference wrapper for combinatorial Reeb cycle verification."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from jaxtyping import Array, Float
+
+from viterbo.symplectic.capacity.facet_normals.reference import (
+    compute_ehz_capacity_reference as _facet_reference,
+)
+from viterbo.symplectic.capacity.reeb_cycles.graph import build_oriented_edge_graph
+
+
+def compute_ehz_capacity_reference(
+    B_matrix: Float[Array, " num_facets dimension"],
+    c_vector: Float[Array, " num_facets"],
+    *,
+    atol: float = 1e-9,
+) -> float:
+    """Compute ``c_EHZ`` while validating the oriented-edge graph."""
+
+    graph = build_oriented_edge_graph(B_matrix, c_vector, atol=atol)
+    if graph.graph.number_of_nodes() == 0:
+        raise ValueError("Oriented-edge graph is empty; polytope lacks admissible edges.")
+    return _facet_reference(B_matrix, c_vector)
+
+
+__all__: Final = ["compute_ehz_capacity_reference"]

--- a/tests/performance/viterbo/symplectic/capacity/reeb_cycles/test_ehz_capacity_benchmarks.py
+++ b/tests/performance/viterbo/symplectic/capacity/reeb_cycles/test_ehz_capacity_benchmarks.py
@@ -1,0 +1,39 @@
+"""Performance benchmarks for the combinatorial Reeb cycle solvers."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+import pytest
+import pytest_benchmark.plugin  # type: ignore[reportMissingTypeStubs]
+
+from tests._utils.polytope_samples import load_polytope_instances
+from viterbo.symplectic.capacity.reeb_cycles.fast import compute_ehz_capacity_fast
+from viterbo.symplectic.capacity.reeb_cycles.reference import compute_ehz_capacity_reference
+
+pytestmark = [pytest.mark.smoke, pytest.mark.deep]
+
+_POLYTOPES = load_polytope_instances()
+_POLYTOPE_INSTANCES = _POLYTOPES[0]
+_POLYTOPE_IDS = _POLYTOPES[1]
+
+
+@pytest.mark.benchmark(group="reeb-cycles")
+@pytest.mark.parametrize(("B", "c"), _POLYTOPE_INSTANCES, ids=_POLYTOPE_IDS)
+def test_fast_matches_reference(
+    benchmark: pytest_benchmark.plugin.BenchmarkFixture,
+    B: np.ndarray,
+    c: np.ndarray,
+) -> None:
+    """Benchmark the optimized solver against the reference implementation."""
+
+    try:
+        reference = compute_ehz_capacity_reference(B, c)
+    except ValueError as error:
+        with pytest.raises(ValueError) as caught:
+            benchmark(lambda: compute_ehz_capacity_fast(B, c))
+        assert str(caught.value) == str(error)
+    else:
+        optimized = cast(float, benchmark(lambda: compute_ehz_capacity_fast(B, c)))
+        assert np.isclose(optimized, reference, atol=1e-8)

--- a/tests/viterbo/symplectic/capacity/reeb_cycles/test_fast.py
+++ b/tests/viterbo/symplectic/capacity/reeb_cycles/test_fast.py
@@ -1,0 +1,34 @@
+"""Optimized combinatorial Reeb cycle solver tests."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from viterbo.geometry.polytopes import (
+    simplex_with_uniform_weights,
+    truncated_simplex_four_dim,
+)
+from viterbo.symplectic.capacity.reeb_cycles.fast import (
+    compute_ehz_capacity_fast,
+)
+from viterbo.symplectic.capacity.reeb_cycles.reference import (
+    compute_ehz_capacity_reference,
+)
+
+
+@pytest.mark.parametrize(
+    "polytope_factory",
+    [
+        truncated_simplex_four_dim,
+        lambda: simplex_with_uniform_weights(4, name="uniform-simplex-4d"),
+    ],
+)
+def test_fast_matches_reference(polytope_factory) -> None:
+    polytope = polytope_factory()
+    B, c = polytope.halfspace_data()
+    fast_value = compute_ehz_capacity_fast(B, c)
+    reference_value = compute_ehz_capacity_reference(B, c)
+    assert math.isclose(fast_value, reference_value, rel_tol=0.0, abs_tol=1e-8)
+

--- a/tests/viterbo/symplectic/capacity/reeb_cycles/test_graph.py
+++ b/tests/viterbo/symplectic/capacity/reeb_cycles/test_graph.py
@@ -1,0 +1,40 @@
+"""Graph construction checks for oriented-edge combinatorics."""
+
+from __future__ import annotations
+
+import pytest
+
+from viterbo.geometry.polytopes import regular_polygon_product
+from viterbo.symplectic.capacity.reeb_cycles.graph import build_oriented_edge_graph
+
+
+def _assert_bidirectional(graph) -> None:
+    for edge_id, edge in enumerate(graph.edges):
+        successors = set(graph.outgoing(edge_id))
+        predecessors = set(graph.incoming(edge_id))
+        assert successors or predecessors
+
+
+@pytest.mark.parametrize(
+    "polytope_factory",
+    [
+        lambda: regular_polygon_product(5, 5, rotation=0.0, name="pentagon-product"),
+        lambda: regular_polygon_product(6, 6, rotation=0.0, name="hexagon-product"),
+    ],
+)
+def test_graph_has_edges(polytope_factory) -> None:
+    polytope = polytope_factory()
+    B, c = polytope.halfspace_data()
+    graph = build_oriented_edge_graph(B, c)
+    assert graph.graph.number_of_nodes() > 0
+    assert graph.graph.number_of_edges() > 0
+    _assert_bidirectional(graph)
+
+
+def test_graph_requires_four_dimensions() -> None:
+    from viterbo.geometry.polytopes import simplex_with_uniform_weights
+
+    polytope = simplex_with_uniform_weights(2, name="triangle")
+    B, c = polytope.halfspace_data()
+    with pytest.raises(ValueError):
+        build_oriented_edge_graph(B, c)

--- a/tests/viterbo/symplectic/capacity/reeb_cycles/test_reference.py
+++ b/tests/viterbo/symplectic/capacity/reeb_cycles/test_reference.py
@@ -1,0 +1,42 @@
+"""Reference solver regression tests for combinatorial Reeb cycles."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from viterbo.geometry.polytopes import (
+    simplex_with_uniform_weights,
+    truncated_simplex_four_dim,
+)
+from viterbo.symplectic.capacity.facet_normals.reference import (
+    compute_ehz_capacity_reference as facet_reference,
+)
+from viterbo.symplectic.capacity.reeb_cycles.reference import (
+    compute_ehz_capacity_reference,
+)
+
+
+
+@pytest.mark.parametrize(
+    "polytope_factory",
+    [
+        truncated_simplex_four_dim,
+        lambda: simplex_with_uniform_weights(4, name="uniform-simplex-4d"),
+    ],
+)
+def test_reference_matches_facet_normals(polytope_factory) -> None:
+    polytope = polytope_factory()
+    B, c = polytope.halfspace_data()
+    reeb_capacity = compute_ehz_capacity_reference(B, c)
+    facet_capacity = facet_reference(B, c)
+    assert math.isclose(reeb_capacity, facet_capacity, rel_tol=0.0, abs_tol=1e-8)
+
+
+def test_reference_agrees_with_polytope_metadata() -> None:
+    polytope = truncated_simplex_four_dim()
+    assert polytope.reference_capacity is not None
+    B, c = polytope.halfspace_data()
+    reeb_capacity = compute_ehz_capacity_reference(B, c)
+    assert math.isclose(reeb_capacity, polytope.reference_capacity, rel_tol=0.0, abs_tol=1e-9)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
@@ -816,6 +816,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
 ]
 
 [[package]]
@@ -1657,6 +1666,7 @@ dependencies = [
     { name = "jax" },
     { name = "jaxopt" },
     { name = "jaxtyping" },
+    { name = "networkx" },
     { name = "numpy" },
     { name = "orbax-checkpoint" },
     { name = "pyarrow" },
@@ -1698,6 +1708,7 @@ requires-dist = [
     { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.0" },
     { name = "mkdocs-htmlproofer-plugin", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.40" },
+    { name = "networkx", specifier = ">=3.2.1" },
     { name = "numpy", specifier = ">=2.3.3" },
     { name = "orbax-checkpoint", specifier = ">=0.11.25" },
     { name = "py-spy", marker = "extra == 'dev'", specifier = ">=0.4.1" },


### PR DESCRIPTION
## Summary
- add a `reeb_cycles` package that exposes graph construction plus reference and fast wrappers
- register the new wrappers in the capacity namespace and depend on `networkx`
- cover the scaffolding with correctness and benchmark tests for representative 4D polytopes
- draft a Chaidez–Hutchings Reeb-cycle solver implementation brief outlining blockers, scope, and unblocking steps

## Testing
- `uv run pytest tests/viterbo/symplectic/capacity/reeb_cycles -k "not benchmark"` (previous run; not rerun for docs-only update)


------
https://chatgpt.com/codex/tasks/task_e_68e403e62eac832b8f2768e6661b4052