### PR TITLE
Add systolic exploration proposal briefs

### DIFF
--- a/docs/briefs/2025-10-07-task-combinatorial-reeb-formalization.md
+++ b/docs/briefs/2025-10-07-task-combinatorial-reeb-formalization.md
@@ -1,0 +1,35 @@
+---
+status: proposed
+created: 2025-10-07
+source: chatgpt-pro-2025-10-07
+summary: Document and implement the combinatorial Reeb framework for 4D polytopes.
+---
+
+# Combinatorial Reeb model formalization
+
+## Motivation
+
+The ChatGPT Pro session stresses that Chaidez–Hutchings’ combinatorial Reeb model is the mathematical backbone aligning polytope dynamics with smooth Reeb flows. Formalising it ensures our computations have a solid theoretical anchor.
+
+## Scope
+
+- Translate the combinatorial Reeb orbit construction (facet itineraries, action, Conley–Zehnder index) into repository documentation and code interfaces.
+- Prove and test invariance properties (scaling, symplectic linear maps) at the model level.
+- Encode the Minkowski billiard correspondence for Lagrangian products \(K \times T\) and map it to EHZ capacity computations.
+
+## Deliverables
+
+1. Design doc describing the discrete Reeb model and smoothing correspondence.
+2. Reference implementation with unit tests powered by [Baseline invariants](2025-10-07-task-systolic-baselines.md).
+3. Examples covering \(K \times K^\circ\) and other benchmark domains.
+
+## Dependencies & Links
+
+- Consumes regression fixtures from [Baseline invariants](2025-10-07-task-systolic-baselines.md).
+- Required by [Systolic computation pipeline](2025-10-07-task-systolic-pipeline.md) and [Landscape scans](2025-10-07-task-systolic-landscape-scans.md).
+- Supports certificate work in [Rigorous certificates and conjecture work](2025-10-07-task-systolic-certificates.md).
+
+## Status Tracking
+
+Update the header `status` when the design doc or implementation lands.
+

--- a/docs/briefs/2025-10-07-task-systolic-advanced-directions.md
+++ b/docs/briefs/2025-10-07-task-systolic-advanced-directions.md
@@ -1,0 +1,35 @@
+---
+status: proposed
+created: 2025-10-07
+source: chatgpt-pro-2025-10-07
+summary: Pursue optimisation, analysis, and literature sweep directions extending the core systolic program.
+---
+
+# Advanced optimization and analysis directions
+
+## Motivation
+
+The ChatGPT Pro outline closes with supplementary tracks—shape derivatives, optimisation, topological data analysis, dynamical convexity, and literature monitoring—that refine or extend the main program.
+
+## Scope
+
+- Implement shape-derivative calculations for \(c_{\mathrm{EHZ}}\) via support number perturbations, providing gradients for search.
+- Run optimisation loops (CMA-ES, Bayesian optimisation) over polytope support numbers, handing promising violators to [Rigorous certificates](2025-10-07-task-systolic-certificates.md).
+- Apply topological data analysis to action spectra, study dynamical convexity of smoothings, and maintain a literature log on new systolic bounds.
+
+## Deliverables
+
+1. Gradient/shape derivative tooling integrated with the systolic pipeline.
+2. Optimisation workflows with clear seeding, constraints, and certificate hand-offs.
+3. Reports summarising TDA findings, dynamical convexity status, and literature updates.
+
+## Dependencies & Links
+
+- Builds on [Systolic computation pipeline](2025-10-07-task-systolic-pipeline.md) and data from [Landscape scans](2025-10-07-task-systolic-landscape-scans.md).
+- Requires certificate integration per [Rigorous certificates and conjecture work](2025-10-07-task-systolic-certificates.md).
+- Consumes insights from [Machine learning program](2025-10-07-task-systolic-ml-program.md) for prioritising search regions.
+
+## Status Tracking
+
+Use this brief to record progress across the sub-directions; update status when the bundle of activities matures or spins into independent briefs.
+

--- a/docs/briefs/2025-10-07-task-systolic-baselines.md
+++ b/docs/briefs/2025-10-07-task-systolic-baselines.md
@@ -1,0 +1,34 @@
+---
+status: proposed
+created: 2025-10-07
+source: chatgpt-pro-2025-10-07
+summary: Build reference polytopes and invariance tests to anchor systolic computations.
+---
+
+# Baseline invariants and regression tests for systolic ratio tooling
+
+## Motivation
+
+Reproducing the simple families from the ChatGPT Pro plan (ellipsoids, products, symplectic transforms) gives us a trusted yardstick before investing in heavier computations.
+
+## Scope
+
+- Implement sanity checks for \(\text{sys}(X)\) invariance under scaling and linear symplectomorphisms.
+- Produce dual H/V representations and confirm consistent volumes and capacities.
+- Curate a reference library of centrally symmetric 4D polytopes, including Lagrangian products of 2D polygons, to ship with the repository.
+
+## Deliverables
+
+1. Automated test suite covering ellipsoids and product domains with known \(\text{sys}(X)\) values.
+2. Reproducible scripts/data for the reference polytope set.
+3. Documentation summarising expected outputs and tolerances.
+
+## Dependencies & Links
+
+- Enables [Combinatorial Reeb model formalization](2025-10-07-task-combinatorial-reeb-formalization.md) and [Systolic computation pipeline](2025-10-07-task-systolic-pipeline.md).
+- Feeds regression fixtures for [Landscape scans and reproductions](2025-10-07-task-systolic-landscape-scans.md).
+
+## Status Tracking
+
+Status stays `proposed` until tests and data are merged; update this file when work starts or completes.
+

--- a/docs/briefs/2025-10-07-task-systolic-certificates.md
+++ b/docs/briefs/2025-10-07-task-systolic-certificates.md
@@ -1,0 +1,35 @@
+---
+status: proposed
+created: 2025-10-07
+source: chatgpt-pro-2025-10-07
+summary: Produce rigorous systolic ratio certificates and conjecture statements based on computational evidence.
+---
+
+# Rigorous certificates and conjecture work
+
+## Motivation
+
+Following the ChatGPT Pro plan, we want machine-checkable evidence for \(\text{sys}(X)>1\) and structured conjectures grounded in data.
+
+## Scope
+
+- Build a certificate pipeline for rational polytopes, capturing Reeb orbit action bounds, exact volumes, and exhaustive search cutoffs.
+- Articulate conjectures on subclasses (e.g., \(K \times K^\circ\), unconditional polytopes), backed by computed datasets.
+- Analyse neighbourhoods around counterexamples to study stability of violations.
+
+## Deliverables
+
+1. JSON/PDF certificate format documenting orbit bounds and resulting inequalities.
+2. Repository notes summarising conjectures, empirical support, and cross-links to relevant scans.
+3. Tooling to regenerate certificates when polytope data updates.
+
+## Dependencies & Links
+
+- Consumes candidates and data from [Landscape scans and reproductions](2025-10-07-task-systolic-landscape-scans.md).
+- Uses infrastructure from [Systolic computation pipeline](2025-10-07-task-systolic-pipeline.md) and theoretical guarantees from [Combinatorial Reeb formalization](2025-10-07-task-combinatorial-reeb-formalization.md).
+- Provides labelled exemplars for [Machine learning program](2025-10-07-task-systolic-ml-program.md) and targets for [Advanced optimization directions](2025-10-07-task-systolic-advanced-directions.md).
+
+## Status Tracking
+
+Update the status when the certificate format or first certified counterexample lands; record conjecture revisions inline.
+

--- a/docs/briefs/2025-10-07-task-systolic-landscape-scans.md
+++ b/docs/briefs/2025-10-07-task-systolic-landscape-scans.md
@@ -1,0 +1,36 @@
+---
+status: proposed
+created: 2025-10-07
+source: chatgpt-pro-2025-10-07
+summary: Run computational experiments to map systolic behaviour and reproduce literature results.
+---
+
+# Landscape scans and reproductions
+
+## Motivation
+
+The ChatGPT Pro milestones call for replicating Chaidez–Hutchings and Haim-Kislev–Ostrover experiments, then exploring broader polytope families to visualise where Viterbo’s conjecture fails.
+
+## Scope
+
+- Reproduce published datasets (Chaidez–Hutchings examples with \(\text{sys}=1\); the counterexample \(P\) with \(\text{sys}(P)>1\)).
+- Generate landscape scans over structured families (e.g., \(K \times K^\circ\), unconditional polytopes, random normals) with histogram and action spectrum summaries.
+- Track which combinatorial orbit types realise \(\mathrm{A}_{\min}\) across the scans.
+
+## Deliverables
+
+1. Notebooks or scripts producing replication tables with error bars.
+2. Data artefacts (CSV/Parquet) capturing scans, ready for downstream ML.
+3. Visual summaries illustrating distributions and qualitative phenomena.
+
+## Dependencies & Links
+
+- Requires [Systolic computation pipeline](2025-10-07-task-systolic-pipeline.md) and [Combinatorial Reeb formalization](2025-10-07-task-combinatorial-reeb-formalization.md).
+- Uses fixtures from [Baseline invariants](2025-10-07-task-systolic-baselines.md).
+- Feeds [Rigorous certificates and conjecture work](2025-10-07-task-systolic-certificates.md) with candidate polytopes.
+- Supplies datasets for [Machine learning program](2025-10-07-task-systolic-ml-program.md) and diagnostics for [Advanced optimization directions](2025-10-07-task-systolic-advanced-directions.md).
+
+## Status Tracking
+
+Update status as replication and scanning milestones complete; note any blocking literature clarifications.
+

--- a/docs/briefs/2025-10-07-task-systolic-ml-program.md
+++ b/docs/briefs/2025-10-07-task-systolic-ml-program.md
@@ -1,0 +1,35 @@
+---
+status: proposed
+created: 2025-10-07
+source: chatgpt-pro-2025-10-07
+summary: Develop surrogate models and hypothesis mining tools for systolic ratios.
+---
+
+# Machine learning surrogate program
+
+## Motivation
+
+Per the ChatGPT Pro plan, ML should accelerate exploration by predicting \(\text{sys}(X)\), flagging likely violations, and surfacing structural hypotheses.
+
+## Scope
+
+- Engineer polytope and Reeb-derived feature sets suitable for classical models and graph neural networks.
+- Train calibrated predictors (e.g., gradient boosting, conformal wrappers, GNNs) on datasets from [Landscape scans](2025-10-07-task-systolic-landscape-scans.md).
+- Explore hypothesis mining tools (mutual information estimators, symbolic regression) to propose interpretable relations.
+
+## Deliverables
+
+1. Feature extraction library referencing inputs from the systolic pipeline.
+2. Model training scripts with evaluation dashboards and uncertainty calibration metrics.
+3. Hypothesis reports linking mined relations to conjecture work in [Rigorous certificates](2025-10-07-task-systolic-certificates.md).
+
+## Dependencies & Links
+
+- Requires data from [Landscape scans and reproductions](2025-10-07-task-systolic-landscape-scans.md) and certificates from [Rigorous certificates and conjecture work](2025-10-07-task-systolic-certificates.md).
+- Relies on implementations from [Systolic computation pipeline](2025-10-07-task-systolic-pipeline.md) for feature generation.
+- Informs optimisation strategies in [Advanced optimization and analysis directions](2025-10-07-task-systolic-advanced-directions.md).
+
+## Status Tracking
+
+Mark progress as datasets become available, models train successfully, and hypothesis mining yields actionable leads.
+

--- a/docs/briefs/2025-10-07-task-systolic-overview.md
+++ b/docs/briefs/2025-10-07-task-systolic-overview.md
@@ -1,0 +1,39 @@
+---
+status: proposed
+created: 2025-10-07
+source: chatgpt-pro-2025-10-07
+summary: Cohesive milestone group translating ChatGPT Pro planning notes into actionable briefs on probing Viterbo's conjecture computationally.
+---
+
+# Systolic Ratio Exploration Overview
+
+This bundle records the project outline suggested by the 2025-10-07 ChatGPT Pro session focused on building computational and mathematical tooling around systolic ratios of 4D polytopes. Each linked brief elaborates one strand of work; together they form an end-to-end exploration program from baseline validation through machine-driven discovery.
+
+## Goal
+
+Coordinate the milestones that will let us compute, certify, and explore systolic ratios for convex polytopes in \(\mathbb{R}^4\), including data-driven hypothesis generation and rigorous verification.
+
+## Brief Map
+
+- [Baseline invariants and regression tests](2025-10-07-task-systolic-baselines.md) – foundational checks.
+- [Combinatorial Reeb model formalization](2025-10-07-task-combinatorial-reeb-formalization.md) – mathematical backbone.
+- [Systolic computation pipeline](2025-10-07-task-systolic-pipeline.md) – engineering workhorse.
+- [Landscape scans and reproductions](2025-10-07-task-systolic-landscape-scans.md) – initial computational experiments.
+- [Rigorous certificates and conjecture work](2025-10-07-task-systolic-certificates.md) – mathematical deliverables.
+- [Machine learning surrogate program](2025-10-07-task-systolic-ml-program.md) – data-driven acceleration.
+- [Advanced optimization and analysis directions](2025-10-07-task-systolic-advanced-directions.md) – supplementary investigations.
+
+## Dependencies & Order
+
+1. Establish baselines before touching other strands.
+2. Formalize the combinatorial Reeb model in tandem with the systolic pipeline; both depend on the baseline tests.
+3. Landscape scans require the pipeline plus Reeb model formalization.
+4. Rigorous certificates build atop scans and the pipeline, feeding back into baselines when new counterexamples emerge.
+5. Machine learning consumes the atlas from landscape scans and certificate outputs for labels.
+6. Advanced directions (shape derivatives, optimization, TDA, dynamical convexity, literature sweeps) rely on earlier milestones but can run in parallel once baselines, pipeline, and scans exist.
+
+## Notes
+
+- Track completion of this group via this overview; mark each linked brief's status when started or finished.
+- Follow-up task: compare these proposals against existing implementations under `src/viterbo/` to identify overlaps or gaps.
+

--- a/docs/briefs/2025-10-07-task-systolic-pipeline.md
+++ b/docs/briefs/2025-10-07-task-systolic-pipeline.md
@@ -1,0 +1,36 @@
+---
+status: proposed
+created: 2025-10-07
+source: chatgpt-pro-2025-10-07
+summary: Engineer a performant systolic ratio computation stack for 4D polytopes.
+---
+
+# Systolic computation pipeline
+
+## Motivation
+
+We need a robust, modular implementation to compute \(\text{sys}(X)\) efficiently across large polytope families, as outlined in the ChatGPT Pro plan’s engineering milestones.
+
+## Scope
+
+- Build core libraries for polytope representations, smoothing, volume calculation, and combinatorial Reeb orbit enumeration.
+- Provide performance instrumentation covering runtime vs. facet count and action cutoffs.
+- Offer numerical robustness modes (float64, interval arithmetic, rational support) with clear toggles.
+
+## Deliverables
+
+1. Library modules aligning with the plan’s `Polytope4D`, `ReebOrbit`, and `Smoothing` data models.
+2. Benchmark scripts documenting scaling behaviour, feeding into repository performance baselines.
+3. User documentation explaining configuration options and recommended workflows.
+
+## Dependencies & Links
+
+- Consumes theoretical work from [Combinatorial Reeb model formalization](2025-10-07-task-combinatorial-reeb-formalization.md).
+- Relies on regression fixtures defined in [Baseline invariants](2025-10-07-task-systolic-baselines.md).
+- Supports [Landscape scans and reproductions](2025-10-07-task-systolic-landscape-scans.md), [Rigorous certificates](2025-10-07-task-systolic-certificates.md), and [Machine learning program](2025-10-07-task-systolic-ml-program.md).
+- Shares performance insights with [Advanced optimization and analysis directions](2025-10-07-task-systolic-advanced-directions.md).
+
+## Status Tracking
+
+Update the YAML header as modules land; keep notes on performance regressions or toolchain needs.
+


### PR DESCRIPTION
## Summary
- add an overview tying together the systolic exploration plan from the 2025-10-07 ChatGPT Pro session
- capture individual briefs for baselines, combinatorial Reeb formalization, pipeline work, landscape scans, certification, machine learning, and advanced directions with dependencies and status metadata

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e522a30d58832bad261bca6eafd659